### PR TITLE
Swap the keys for SongMessage and SongMessageOrInstruments.

### DIFF
--- a/src/module/metadata.rs
+++ b/src/module/metadata.rs
@@ -41,8 +41,8 @@ impl MetadataKey {
 			ModuleArtist => "artist",
 			ModuleTracker => "tracker",
 			ModuleSaveDate => "date",
-			SongMessage => "message",
-			SongMessageOrInstruments => "message_raw",
+			SongMessage => "message_raw",
+			SongMessageOrInstruments => "message",
 			LoadWarnings => "warnings",
 		}
 	}


### PR DESCRIPTION
According to:

https://lib.openmpt.org/doc/group__libopenmpt__c.html#gac171f8fb2c7a0b998855956069159068

"message" is the message or instruments, while "message_raw" is just the
message (or empty string).