### PR TITLE
Mark Module as Send

### DIFF
--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -33,6 +33,8 @@ pub struct Module {
 	inner : *mut openmpt_sys::openmpt_module,
 }
 
+unsafe impl Send for Module { }
+
 impl Drop for Module {
 	fn drop(&mut self) {
 		unsafe {


### PR DESCRIPTION
Because it includes the raw pointer `*mut openmpt_sys::openmpt_module`, `Module` is not automatically `Send`. However, as far as I can tell, it's valid for it to implement `Send`.  According to the [C API docs](https://lib.openmpt.org/doc/libopenmpt_c_overview.html):

* libopenmpt is thread-aware.
* Individual libopenmpt objects are not thread-safe.
* libopenmpt itself does not spawn any user-visible threads but may spawn threads for internal use.
* You must ensure to only ever access a particular libopenmpt object from a single thread at a time.
* Consecutive accesses can happen from different threads.
* Different objects can be accessed concurrently from different threads.

So it's safe to send OpenMPT pointers to different threads, as long as access is guarded, e.g. with a mutex.  So `Sync` wouldn't be good, but `Send` is just fine, and will allow `Module` to be wrapped in a mutex.
