### PR TITLE
Add Send impl for Module

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -7,65 +7,64 @@ use std::str;
 /// A struct containing the OpenMPT version number, in big-endian.
 ///
 /// `CoreVersion(majormajor, major, minor, minorminor)`
-pub struct CoreVersion (pub u8,	pub u8,	pub u8,	pub u8);
+pub struct CoreVersion(pub u8, pub u8, pub u8, pub u8);
 
 #[derive(Debug)]
 /// A struct containing the libopenmpt version number, in big-endian.
 ///
 /// `LibraryVersion(major, minor, revision)`
-pub struct LibraryVersion (pub u8, pub u8, pub u16);
+pub struct LibraryVersion(pub u8, pub u8, pub u16);
 
 #[derive(Debug)]
 /// An enum containing all the potentially valid keys for `openmpt_get_string`
 pub enum InfoField {
-	/// Verbose library version string
+    /// Verbose library version string
     LibraryVersion,
-	/// Verbose library features string
+    /// Verbose library features string
     LibraryFeatures,
-	/// Verbose OpenMPT core version string
-	CoreVersion,
-	/// Original source code URL
-	SourceURL,
-	/// Original source code date
-	SourceDate,
-	/// Information about the current build (e.g. the build date or compiler used)
-	Build,
-	/// Information about the compiler used to build libopenmpt
-	BuildCompiler,
-	/// All contributors
-	Credits,
-	/// Contact information about libopenmpt
-	Contact,
-	/// The libopenmpt license
-	License,
-	/// libopenmpt website URL
-	URL,
-	/// libopenmpt support and discussions forum URL
-	SupportForumUrl,
-	/// libopenmpt bug and issue tracker URL
-	BugtrackerURL,
+    /// Verbose OpenMPT core version string
+    CoreVersion,
+    /// Original source code URL
+    SourceURL,
+    /// Original source code date
+    SourceDate,
+    /// Information about the current build (e.g. the build date or compiler used)
+    Build,
+    /// Information about the compiler used to build libopenmpt
+    BuildCompiler,
+    /// All contributors
+    Credits,
+    /// Contact information about libopenmpt
+    Contact,
+    /// The libopenmpt license
+    License,
+    /// libopenmpt website URL
+    URL,
+    /// libopenmpt support and discussions forum URL
+    SupportForumUrl,
+    /// libopenmpt bug and issue tracker URL
+    BugtrackerURL,
 }
 
 impl InfoField {
-	fn to_str(&self) -> &str {
-		use self::InfoField::*;
-		match *self {
-
-			LibraryVersion =>  "library_version",
-			LibraryFeatures => "library_features",
-			CoreVersion => "core_version",
-			SourceURL => "source_url",
-			SourceDate => "source_date",
-			Build => "build",
-			BuildCompiler => "build_compiler",
-			Credits => "credits",
-			Contact => "contact",
-			License => "license",
-			URL => "url",
-			SupportForumUrl => "support_forum_url",
-			BugtrackerURL => "bugtracker_url",
-		}
-	}
+    fn to_str(&self) -> &str {
+        use self::InfoField::*;
+        match *self {
+            LibraryVersion => "library_version",
+            LibraryFeatures => "library_features",
+            CoreVersion => "core_version",
+            SourceURL => "source_url",
+            SourceDate => "source_date",
+            Build => "build",
+            BuildCompiler => "build_compiler",
+            Credits => "credits",
+            Contact => "contact",
+            License => "license",
+            URL => "url",
+            SupportForumUrl => "support_forum_url",
+            BugtrackerURL => "bugtracker_url",
+        }
+    }
 }
 
 /// Get a library-related metadata string.
@@ -76,11 +75,9 @@ impl InfoField {
 /// ### Returns
 /// A (possibly multi-line) string containing the queried information.
 /// If no information is available, the string is empty.
-pub fn get_string (field : &InfoField) -> Option<String> {
-	let field = field.to_str();
-	get_string_with_string!(field, {
-		openmpt_sys::openmpt_get_string(field)
-	})
+pub fn get_string(field: &InfoField) -> Option<String> {
+    let field = field.to_str();
+    get_string_with_string!(field, { openmpt_sys::openmpt_get_string(field) })
 }
 
 /// Get a list of supported file extensions.
@@ -90,11 +87,11 @@ pub fn get_string (field : &InfoField) -> Option<String> {
 /// the libopenmpt build. The extensions are returned lower-case
 /// without a leading dot.
 pub fn get_supported_extensions() -> String {
-	let opt_string = get_string!{
-		openmpt_sys::openmpt_get_supported_extensions()
-	};
+    let opt_string = get_string! {
+        openmpt_sys::openmpt_get_supported_extensions()
+    };
 
-	opt_string.expect("Got null pointer instead of string")
+    opt_string.expect("Got null pointer instead of string")
 }
 
 /// Query whether a file extension is supported.
@@ -104,13 +101,13 @@ pub fn get_supported_extensions() -> String {
 ///
 /// ### Returns
 /// Whether a module tracker format with that extension is supported or not.
-pub fn is_extension_supported(extension : &str) -> bool {
-	let result = with_string!(extension, {
-		openmpt_sys::openmpt_is_extension_supported(extension)
-	});
+pub fn is_extension_supported(extension: &str) -> bool {
+    let result = with_string!(extension, {
+        openmpt_sys::openmpt_is_extension_supported(extension)
+    });
 
-	// Returns : 1 if the extension is supported by libopenmpt, 0 otherwise.
-	if result == 1 { true } else { false }
+    // Returns : 1 if the extension is supported by libopenmpt, 0 otherwise.
+    result == 1
 }
 
 /// Get the OpenMPT core version number.
@@ -119,17 +116,15 @@ pub fn is_extension_supported(extension : &str) -> bool {
 /// A struct containing the OpenMPT version number, in big-endian :
 ///
 /// `CoreVersion(majormajor, major, minor, minorminor)`
-pub fn get_core_version () -> CoreVersion {
-	let version_number = unsafe {
-		openmpt_sys::openmpt_get_core_version()
-	};
+pub fn get_core_version() -> CoreVersion {
+    let version_number = unsafe { openmpt_sys::openmpt_get_core_version() };
 
-	CoreVersion (
-		(version_number >> 24) as u8,
-		(version_number >> 16) as u8,
-		(version_number >> 8)  as u8,
-		version_number  as u8
-	)
+    CoreVersion(
+        (version_number >> 24) as u8,
+        (version_number >> 16) as u8,
+        (version_number >> 8) as u8,
+        version_number as u8,
+    )
 }
 
 /// Get the libopenmpt version number.
@@ -138,49 +133,47 @@ pub fn get_core_version () -> CoreVersion {
 /// A struct containing the libopenmpt version number, in big-endian :
 ///
 /// `LibraryVersion(major, minor, revision)`
-pub fn get_library_version () -> LibraryVersion {
-	let version_number = unsafe {
-		openmpt_sys::openmpt_get_library_version()
-	};
+pub fn get_library_version() -> LibraryVersion {
+    let version_number = unsafe { openmpt_sys::openmpt_get_library_version() };
 
-	LibraryVersion (
-		(version_number >> 24) as u8,
-		(version_number >> 16)  as u8,
-		version_number as u16
-	)
+    LibraryVersion(
+        (version_number >> 24) as u8,
+        (version_number >> 16) as u8,
+        version_number as u16,
+    )
 }
 
 #[cfg(test)]
 mod tests {
-	#[test]
-	fn try_lib_version_field() {
-		// Those should always return something
-		test_info_field(&super::InfoField::LibraryVersion);
-		test_info_field(&super::InfoField::LibraryFeatures);
-		test_info_field(&super::InfoField::CoreVersion);
-	}
+    #[test]
+    fn try_lib_version_field() {
+        // Those should always return something
+        test_info_field(&super::InfoField::LibraryVersion);
+        test_info_field(&super::InfoField::LibraryFeatures);
+        test_info_field(&super::InfoField::CoreVersion);
+    }
 
-	fn test_info_field(field : &super::InfoField) {
-		let val = super::get_string(&field).unwrap();
-		println!("Field {:?} : \"{}\"", &field, &val);		
-	}
+    fn test_info_field(field: &super::InfoField) {
+        let val = super::get_string(&field).unwrap();
+        println!("Field {:?} : \"{}\"", &field, &val);
+    }
 
-	#[test]
-	fn supported_extensions_include_xm() {
-		let support_list = super::get_supported_extensions();
-		assert!(support_list.contains("xm"));
-	}
+    #[test]
+    fn supported_extensions_include_xm() {
+        let support_list = super::get_supported_extensions();
+        assert!(support_list.contains("xm"));
+    }
 
-	#[test]
-	fn xm_is_supported() {
-		assert!(super::is_extension_supported("xm"));
-	}
+    #[test]
+    fn xm_is_supported() {
+        assert!(super::is_extension_supported("xm"));
+    }
 
-	#[test]
-	fn show_version_numbers() {
-		let x = super::get_core_version();
-		println!("Core Version : {:?}", &x);
-		let y = super::get_library_version();
-		println!("Lib Version : {:?}", &y);
-	}
+    #[test]
+    fn show_version_numbers() {
+        let x = super::get_core_version();
+        println!("Core Version : {:?}", &x);
+        let y = super::get_library_version();
+        println!("Lib Version : {:?}", &y);
+    }
 }

--- a/src/mod_command.rs
+++ b/src/mod_command.rs
@@ -5,170 +5,177 @@
 //! They are not part of the public API and change to OpenMPT may break those without warning.
 //! They are only available here for the sake of conveinience and completeness.
 
-const NOTE_NONE:u8 = 0;
-const NOTE_MIN:u8 = 1;
-const NOTE_MAX:u8 = 120;
-const NOTE_MIDDLEC:u8 = 5 * 12 + NOTE_MIN;
-const NOTE_KEYOFF:u8 = 0xFF;
-const NOTE_NOTECUT:u8 = 0xFE;
-const NOTE_FADE:u8 = 0xFD;
-const NOTE_PC:u8 = 0xFC;
-const NOTE_PCS:u8 = 0xFB;
+const NOTE_NONE: u8 = 0;
+const NOTE_MIN: u8 = 1;
+const NOTE_MAX: u8 = 120;
+const NOTE_MIDDLEC: u8 = 5 * 12 + NOTE_MIN;
+const NOTE_KEYOFF: u8 = 0xFF;
+const NOTE_NOTECUT: u8 = 0xFE;
+const NOTE_FADE: u8 = 0xFD;
+const NOTE_PC: u8 = 0xFC;
+const NOTE_PCS: u8 = 0xFB;
 
 pub struct ModCommand {
-	pub note : Note,
-	pub instr: u8,
-	pub volcmd: VolumeCommand,
-	pub command: EffectCommand,
+    pub note: Note,
+    pub instr: u8,
+    pub volcmd: VolumeCommand,
+    pub command: EffectCommand,
 }
 
 impl ModCommand {
-	/// Construct a ModCommand from pattern cell data.
-	///
-	/// ### Parameters
-	/// * `note` : The raw note command
-	/// * `instr` : The raw instrument index
-	/// * `volcmd` : The raw volume command
-	/// * `command` : The raw effect command
-	/// * `vol` : The raw volume parameter
-	/// * `param` : The raw effect parameter
-	///
-	/// ### Returns
-	/// The resulting ModCommand, or an error message
-	/// if one of the parameter has an unknown or invalid value
-	pub fn new(note : u8, instr : u8, volcmd : u8, command : u8, vol : u8, param : u8) -> Result<ModCommand, String> {
-		let note_type = ModCommand::note_from_value(note);
-		let note_type = match note_type {
-			Ok(n) => n,
-			Err(e) => return Err(e),
-		};
+    /// Construct a ModCommand from pattern cell data.
+    ///
+    /// ### Parameters
+    /// * `note` : The raw note command
+    /// * `instr` : The raw instrument index
+    /// * `volcmd` : The raw volume command
+    /// * `command` : The raw effect command
+    /// * `vol` : The raw volume parameter
+    /// * `param` : The raw effect parameter
+    ///
+    /// ### Returns
+    /// The resulting ModCommand, or an error message
+    /// if one of the parameter has an unknown or invalid value
+    pub fn new(
+        note: u8,
+        instr: u8,
+        volcmd: u8,
+        command: u8,
+        vol: u8,
+        param: u8,
+    ) -> Result<ModCommand, String> {
+        let note_type = ModCommand::note_from_value(note);
+        let note_type = match note_type {
+            Ok(n) => n,
+            Err(e) => return Err(e),
+        };
 
-		let vol_type = ModCommand::volume_from_command_param(volcmd, vol);
-		let vol_type = match vol_type {
-			Ok(v) => v,
-			Err(e) => return Err(e),
-		};
+        let vol_type = ModCommand::volume_from_command_param(volcmd, vol);
+        let vol_type = match vol_type {
+            Ok(v) => v,
+            Err(e) => return Err(e),
+        };
 
-		let effect_type = ModCommand::effect_from_command_param(command, param);
-		let effect_type = match effect_type {
-			Ok(c) => c,
-			Err(e) => return Err(e),
-		};
+        let effect_type = ModCommand::effect_from_command_param(command, param);
+        let effect_type = match effect_type {
+            Ok(c) => c,
+            Err(e) => return Err(e),
+        };
 
-		Ok(ModCommand {
-			note: note_type,
-			instr: instr,
-			volcmd: vol_type,
-			command: effect_type,
-		})
-	}
+        Ok(ModCommand {
+            note: note_type,
+            instr,
+            volcmd: vol_type,
+            command: effect_type,
+        })
+    }
 
-	/// Returns the note index corresponding to a middle C (C4).
-	pub fn middle_c() -> u8 {
-		NOTE_MIDDLEC
-	}
+    /// Returns the note index corresponding to a middle C (C4).
+    pub fn middle_c() -> u8 {
+        NOTE_MIDDLEC
+    }
 
-	fn note_from_value(note_val : u8) -> Result<Note, String> {
-		match note_val {
-			NOTE_NONE => Ok(Note::None),
-			NOTE_MIN...NOTE_MAX => Ok(Note::Note(note_val)),
-			NOTE_KEYOFF => Ok(Note::Special(SpecialNote::KeyOff)),
-			NOTE_NOTECUT => Ok(Note::Special(SpecialNote::NoteCut)),
-			NOTE_FADE => Ok(Note::Special(SpecialNote::Fade)),
-			NOTE_PC => Ok(Note::Special(SpecialNote::ParamControl)),
-			NOTE_PCS => Ok(Note::Special(SpecialNote::ParamControlSmooth)),
-			_ => Err("Invalid note".to_owned()),
-		}
-	}
+    fn note_from_value(note_val: u8) -> Result<Note, String> {
+        match note_val {
+            NOTE_NONE => Ok(Note::None),
+            NOTE_MIN..=NOTE_MAX => Ok(Note::Note(note_val)),
+            NOTE_KEYOFF => Ok(Note::Special(SpecialNote::KeyOff)),
+            NOTE_NOTECUT => Ok(Note::Special(SpecialNote::NoteCut)),
+            NOTE_FADE => Ok(Note::Special(SpecialNote::Fade)),
+            NOTE_PC => Ok(Note::Special(SpecialNote::ParamControl)),
+            NOTE_PCS => Ok(Note::Special(SpecialNote::ParamControlSmooth)),
+            _ => Err("Invalid note".to_owned()),
+        }
+    }
 
-	fn effect_from_command_param(cmd : u8, param : u8) -> Result<EffectCommand, String> {
-		let nibble_x = (param & 0xF0) >> 4;
-		let nibble_y = param & 0x0F;
+    fn effect_from_command_param(cmd: u8, param: u8) -> Result<EffectCommand, String> {
+        let nibble_x = (param & 0xF0) >> 4;
+        let nibble_y = param & 0x0F;
 
-		match cmd {
-			0  => Ok(EffectCommand::None),
-			1  => Ok(EffectCommand::Arpeggio(nibble_x, nibble_y)),
-			2  => Ok(EffectCommand::PortamentoUp(param)),
-			3  => Ok(EffectCommand::PortamentoDown(param)),
-			4  => Ok(EffectCommand::TonePortamento(param)),
-			5  => Ok(EffectCommand::Vibrato(nibble_x, nibble_y)),
-			6  => Ok(EffectCommand::TonePortaVol(nibble_x, nibble_y)),
-			7  => Ok(EffectCommand::VibratoVol(nibble_x, nibble_y)),
-			8  => Ok(EffectCommand::Tremolo(nibble_x, nibble_y)),
-			9  => Ok(EffectCommand::Panning8(param)),
-			10 => Ok(EffectCommand::Offset(param)),
-			11 => Ok(EffectCommand::VolumeSlide(nibble_x, nibble_y)),
-			12 => Ok(EffectCommand::PositionJump(param)),
-			13 => Ok(EffectCommand::Volume(param)),
-			14 => Ok(EffectCommand::PatternBreak(param)),
-			15 => Ok(EffectCommand::Retrig(nibble_x, nibble_y)),
-			16 => Ok(EffectCommand::Speed(param)),
-			17 => Ok(EffectCommand::Tempo(param)),
-			18 => Ok(EffectCommand::Tremor(nibble_x, nibble_y)),
-			19 => Ok(EffectCommand::ModCmdEX(nibble_x, nibble_y)),
-			20 => Ok(EffectCommand::S3MCmdEX(nibble_x, nibble_y)),
-			21 => Ok(EffectCommand::ChannelVolume(param)),
-			22 => Ok(EffectCommand::ChannelVolSlide(nibble_x, nibble_y)),
-			23 => Ok(EffectCommand::GlobalVolume(param)),
-			24 => Ok(EffectCommand::GlobalVolSlide(nibble_x, nibble_y)),
-			25 => Ok(EffectCommand::KeyOff(param)),
-			26 => Ok(EffectCommand::FineVibrato(nibble_x, nibble_y)),
-			27 => Ok(EffectCommand::Panbrello(nibble_x, nibble_y)),
-			28 => Ok(EffectCommand::XFinePortaUpDown(nibble_x, nibble_y)),
-			29 => Ok(EffectCommand::PanningSlide(nibble_x, nibble_y)),
-			30 => Ok(EffectCommand::SetEnvPosition(param)),
-			31 => Ok(EffectCommand::Midi(param)),
-			32 => Ok(EffectCommand::SmoothMidi(param)),
-			33 => Ok(EffectCommand::DelayCut(nibble_x, nibble_y)),
-			34 => Ok(EffectCommand::XParam(param)),
-			35 => Ok(EffectCommand::NoteSlideUp(nibble_x, nibble_y)),
-			36 => Ok(EffectCommand::NoteSlideUpRetrig(nibble_x, nibble_y)),
-			37 => Ok(EffectCommand::NoteSlideDown(nibble_x, nibble_y)),
-			38 => Ok(EffectCommand::NoteSlideDownRetrig(nibble_x, nibble_y)),
-			39 => Ok(EffectCommand::ReverseOffset(param)),
-			40 => Ok(EffectCommand::DBMEcho(nibble_x, nibble_y)),
-			41 => Ok(EffectCommand::OffsetPercentage(param)),
-			_ => Err("Invalid effect".to_owned()),
-		}
-	}
+        match cmd {
+            0 => Ok(EffectCommand::None),
+            1 => Ok(EffectCommand::Arpeggio(nibble_x, nibble_y)),
+            2 => Ok(EffectCommand::PortamentoUp(param)),
+            3 => Ok(EffectCommand::PortamentoDown(param)),
+            4 => Ok(EffectCommand::TonePortamento(param)),
+            5 => Ok(EffectCommand::Vibrato(nibble_x, nibble_y)),
+            6 => Ok(EffectCommand::TonePortaVol(nibble_x, nibble_y)),
+            7 => Ok(EffectCommand::VibratoVol(nibble_x, nibble_y)),
+            8 => Ok(EffectCommand::Tremolo(nibble_x, nibble_y)),
+            9 => Ok(EffectCommand::Panning8(param)),
+            10 => Ok(EffectCommand::Offset(param)),
+            11 => Ok(EffectCommand::VolumeSlide(nibble_x, nibble_y)),
+            12 => Ok(EffectCommand::PositionJump(param)),
+            13 => Ok(EffectCommand::Volume(param)),
+            14 => Ok(EffectCommand::PatternBreak(param)),
+            15 => Ok(EffectCommand::Retrig(nibble_x, nibble_y)),
+            16 => Ok(EffectCommand::Speed(param)),
+            17 => Ok(EffectCommand::Tempo(param)),
+            18 => Ok(EffectCommand::Tremor(nibble_x, nibble_y)),
+            19 => Ok(EffectCommand::ModCmdEX(nibble_x, nibble_y)),
+            20 => Ok(EffectCommand::S3MCmdEX(nibble_x, nibble_y)),
+            21 => Ok(EffectCommand::ChannelVolume(param)),
+            22 => Ok(EffectCommand::ChannelVolSlide(nibble_x, nibble_y)),
+            23 => Ok(EffectCommand::GlobalVolume(param)),
+            24 => Ok(EffectCommand::GlobalVolSlide(nibble_x, nibble_y)),
+            25 => Ok(EffectCommand::KeyOff(param)),
+            26 => Ok(EffectCommand::FineVibrato(nibble_x, nibble_y)),
+            27 => Ok(EffectCommand::Panbrello(nibble_x, nibble_y)),
+            28 => Ok(EffectCommand::XFinePortaUpDown(nibble_x, nibble_y)),
+            29 => Ok(EffectCommand::PanningSlide(nibble_x, nibble_y)),
+            30 => Ok(EffectCommand::SetEnvPosition(param)),
+            31 => Ok(EffectCommand::Midi(param)),
+            32 => Ok(EffectCommand::SmoothMidi(param)),
+            33 => Ok(EffectCommand::DelayCut(nibble_x, nibble_y)),
+            34 => Ok(EffectCommand::XParam(param)),
+            35 => Ok(EffectCommand::NoteSlideUp(nibble_x, nibble_y)),
+            36 => Ok(EffectCommand::NoteSlideUpRetrig(nibble_x, nibble_y)),
+            37 => Ok(EffectCommand::NoteSlideDown(nibble_x, nibble_y)),
+            38 => Ok(EffectCommand::NoteSlideDownRetrig(nibble_x, nibble_y)),
+            39 => Ok(EffectCommand::ReverseOffset(param)),
+            40 => Ok(EffectCommand::DBMEcho(nibble_x, nibble_y)),
+            41 => Ok(EffectCommand::OffsetPercentage(param)),
+            _ => Err("Invalid effect".to_owned()),
+        }
+    }
 
-	fn volume_from_command_param(cmd : u8, param : u8) -> Result<VolumeCommand, String> {
-		match cmd {
-			0  => Ok(VolumeCommand::None),
-			1  => Ok(VolumeCommand::Volume(param)),
-			2  => Ok(VolumeCommand::Panning(param)),
-			3  => Ok(VolumeCommand::VolSlideUp(param)),
-			4  => Ok(VolumeCommand::VolSlideDown(param)),
-			5  => Ok(VolumeCommand::FineVolUp(param)),
-			6  => Ok(VolumeCommand::FineVolDown(param)),
-			7  => Ok(VolumeCommand::VibratoSpeed(param)),
-			8  => Ok(VolumeCommand::VibratoDepth(param)),
-			9  => Ok(VolumeCommand::PanSlideLeft(param)),
-			10 => Ok(VolumeCommand::PanSlideRight(param)),
-			11 => Ok(VolumeCommand::TonePortamento(param)),
-			12 => Ok(VolumeCommand::PortaUp(param)),
-			13 => Ok(VolumeCommand::PortaDown(param)),
-			14 => Ok(VolumeCommand::DelayCut(param)),
-			15 => Ok(VolumeCommand::Offset(param)),
-			_  => Err("Invalid volume command".to_owned()),
-		}
-	}
+    fn volume_from_command_param(cmd: u8, param: u8) -> Result<VolumeCommand, String> {
+        match cmd {
+            0 => Ok(VolumeCommand::None),
+            1 => Ok(VolumeCommand::Volume(param)),
+            2 => Ok(VolumeCommand::Panning(param)),
+            3 => Ok(VolumeCommand::VolSlideUp(param)),
+            4 => Ok(VolumeCommand::VolSlideDown(param)),
+            5 => Ok(VolumeCommand::FineVolUp(param)),
+            6 => Ok(VolumeCommand::FineVolDown(param)),
+            7 => Ok(VolumeCommand::VibratoSpeed(param)),
+            8 => Ok(VolumeCommand::VibratoDepth(param)),
+            9 => Ok(VolumeCommand::PanSlideLeft(param)),
+            10 => Ok(VolumeCommand::PanSlideRight(param)),
+            11 => Ok(VolumeCommand::TonePortamento(param)),
+            12 => Ok(VolumeCommand::PortaUp(param)),
+            13 => Ok(VolumeCommand::PortaDown(param)),
+            14 => Ok(VolumeCommand::DelayCut(param)),
+            15 => Ok(VolumeCommand::Offset(param)),
+            _ => Err("Invalid volume command".to_owned()),
+        }
+    }
 }
 
 /// An enum containing the different value for Note commands.
 pub enum Note {
-	None,
-	Note(u8),
-	Special(SpecialNote),
+    None,
+    Note(u8),
+    Special(SpecialNote),
 }
 
 /// An enum containing the special values for Note commands.
 pub enum SpecialNote {
-	KeyOff,
-	NoteCut,
-	Fade,
-	ParamControl,
-	ParamControlSmooth,
+    KeyOff,
+    NoteCut,
+    Fade,
+    ParamControl,
+    ParamControlSmooth,
 }
 
 /// An enum containing the different value for Volume commands.
@@ -183,26 +190,26 @@ pub enum SpecialNote {
 ///
 /// The libopenmpt developpers **do not recommend** relying on these, **you have been warned**.
 pub enum VolumeCommand {
-	None,
-	Volume(u8),
-	Panning(u8),
-	VolSlideUp(u8),
-	VolSlideDown(u8),
-	FineVolUp(u8),
-	FineVolDown(u8),
-	VibratoSpeed(u8),
-	VibratoDepth(u8),
-	PanSlideLeft(u8),
-	PanSlideRight(u8),
-	// Equivalent to the effect, but may be 4 or 16 times less precise
-	TonePortamento(u8),
-	// Equivalent to the effect, but may be 4 or 16 times less precise
-	PortaUp(u8),
-	// Equivalent to the effect, but may be 4 or 16 times less precise
-	PortaDown(u8),
-	// Unused
-	DelayCut(u8),
-	Offset(u8),
+    None,
+    Volume(u8),
+    Panning(u8),
+    VolSlideUp(u8),
+    VolSlideDown(u8),
+    FineVolUp(u8),
+    FineVolDown(u8),
+    VibratoSpeed(u8),
+    VibratoDepth(u8),
+    PanSlideLeft(u8),
+    PanSlideRight(u8),
+    // Equivalent to the effect, but may be 4 or 16 times less precise
+    TonePortamento(u8),
+    // Equivalent to the effect, but may be 4 or 16 times less precise
+    PortaUp(u8),
+    // Equivalent to the effect, but may be 4 or 16 times less precise
+    PortaDown(u8),
+    // Unused
+    DelayCut(u8),
+    Offset(u8),
 }
 
 /// An enum containing the different value for Effect commands.
@@ -218,93 +225,93 @@ pub enum VolumeCommand {
 ///
 /// The libopenmpt developpers **do not recommend** relying on these, **you have been warned**.
 pub enum EffectCommand {
-	None,
-	/// Cycle between note, note+x and note+y on each tick
-	Arpeggio (u8, u8),
-	/// Raise pitch by xy per tick, sometimes including the first
-	///
-	/// Slide fraction is generally 1/16th of a semitone
-	PortamentoUp (u8),
-	/// Lower pitch by xy per tick, sometimes including the first
-	///
-	/// Slide fraction is generally 1/16th of a semitone
-	PortamentoDown (u8),
-	/// Slide pitch of old note towards new note by xy per tick and stop once reached.
-	///
-	/// Slide fraction is generally 1/16th of a semitone
-	TonePortamento (u8),
-	/// Modulates frequency at a speed of x steps (of 64) *PER ROW* and depth y
-	///
-	/// Depth is generally in 1/16th of a semitone
-	Vibrato (u8, u8),
-	/// Volume Slide + Continue portamento
-	TonePortaVol (u8, u8),
-	/// Volume Slide + Continue vibrato
-	VibratoVol (u8, u8),
-	/// Modulates sample volume at a speed of x steps (of 64) *PER ROW* and depth y
-	Tremolo (u8, u8),
-	/// Set panning from 0x0 to 0xF
-	Panning8 (u8),
-	/// Start playing sample at position xy * 256
-	Offset(u8),
-	/// Raise sample volume by x or lower by y on each tick but the first
-	VolumeSlide(u8, u8),
-	/// Jump to pattern at order xy
-	PositionJump(u8),
-	/// Set sample volume at xy (between 0 and 0x40)
-	Volume(u8),
-	/// Jump to row xy of pattern set to play next
-	PatternBreak(u8),
-	/// Retrigger every y ticks, x affects retrigger volume when set
-	Retrig(u8, u8),
-	/// Set speed at xy ticks per row
-	Speed(u8),
-	/// Set tempo at xy beats per minute
-	Tempo(u8),
-	/// Turn volume on for x+1 ticks and mute for y+1 ticks repeatedly
-	Tremor(u8, u8),
-	/// (Mod and XM) Super command, with x the subcommand and y the parameter.
-	ModCmdEX(u8, u8),
-	/// (S3M and IT) Super command, with x the subcommand and y the parameter.
-	S3MCmdEX(u8, u8),
-	/// Set channel volume at xy (between 0 and 0x40)
-	ChannelVolume(u8),
-	/// Raise channel volume by x or lower by y on each tick but the first
-	ChannelVolSlide(u8, u8),
-	/// Set global volume at xy (between 0 and 0x40)
-	GlobalVolume(u8),
-	/// Raise global volume by x or lower by y on each tick but the first
-	GlobalVolSlide(u8, u8),
-	/// Trigger Note Off after xy ticks
-	KeyOff(u8),
-	/// Same as vibrato, but depth is 4 times finer
-	FineVibrato(u8, u8),
-	/// Modulate panning at a speed of x steps (of 64) *PER ROW* and depth y
-	Panbrello(u8, u8),
-	/// (XM only) Super command, with x the subcommand and y the parameter.
-	XFinePortaUpDown(u8, u8),
-	/// Slide panning position right by x or left by y on each tick but the first
-	///
-	/// Depending on format and settings, it could also be apply on the first tick only or on every tick.
-	PanningSlide(u8, u8),
-	/// Sets the volume envelope position to xy ticks
-	SetEnvPosition(u8),
-	/// Execute a midi macro
-	Midi(u8),
-	/// Execute an interpolated midi macro
-	SmoothMidi(u8),
-	/// Delay note for x ticks and cut after another y ticks.
-	///
-	/// If the row ends before either effect is applied (speed is greater than x or x+y), that effect won't be applied.
-	DelayCut(u8, u8),
-	/// Combines the parameter value with the one on the row above it
-	XParam(u8),
-	NoteSlideUp(u8, u8),
-	NoteSlideDown(u8, u8),
-	NoteSlideUpRetrig(u8, u8),
-	NoteSlideDownRetrig(u8, u8),
-	ReverseOffset(u8),
-	// x : chns, y: enable
-	DBMEcho(u8, u8),
-	OffsetPercentage(u8),
+    None,
+    /// Cycle between note, note+x and note+y on each tick
+    Arpeggio(u8, u8),
+    /// Raise pitch by xy per tick, sometimes including the first
+    ///
+    /// Slide fraction is generally 1/16th of a semitone
+    PortamentoUp(u8),
+    /// Lower pitch by xy per tick, sometimes including the first
+    ///
+    /// Slide fraction is generally 1/16th of a semitone
+    PortamentoDown(u8),
+    /// Slide pitch of old note towards new note by xy per tick and stop once reached.
+    ///
+    /// Slide fraction is generally 1/16th of a semitone
+    TonePortamento(u8),
+    /// Modulates frequency at a speed of x steps (of 64) *PER ROW* and depth y
+    ///
+    /// Depth is generally in 1/16th of a semitone
+    Vibrato(u8, u8),
+    /// Volume Slide + Continue portamento
+    TonePortaVol(u8, u8),
+    /// Volume Slide + Continue vibrato
+    VibratoVol(u8, u8),
+    /// Modulates sample volume at a speed of x steps (of 64) *PER ROW* and depth y
+    Tremolo(u8, u8),
+    /// Set panning from 0x0 to 0xF
+    Panning8(u8),
+    /// Start playing sample at position xy * 256
+    Offset(u8),
+    /// Raise sample volume by x or lower by y on each tick but the first
+    VolumeSlide(u8, u8),
+    /// Jump to pattern at order xy
+    PositionJump(u8),
+    /// Set sample volume at xy (between 0 and 0x40)
+    Volume(u8),
+    /// Jump to row xy of pattern set to play next
+    PatternBreak(u8),
+    /// Retrigger every y ticks, x affects retrigger volume when set
+    Retrig(u8, u8),
+    /// Set speed at xy ticks per row
+    Speed(u8),
+    /// Set tempo at xy beats per minute
+    Tempo(u8),
+    /// Turn volume on for x+1 ticks and mute for y+1 ticks repeatedly
+    Tremor(u8, u8),
+    /// (Mod and XM) Super command, with x the subcommand and y the parameter.
+    ModCmdEX(u8, u8),
+    /// (S3M and IT) Super command, with x the subcommand and y the parameter.
+    S3MCmdEX(u8, u8),
+    /// Set channel volume at xy (between 0 and 0x40)
+    ChannelVolume(u8),
+    /// Raise channel volume by x or lower by y on each tick but the first
+    ChannelVolSlide(u8, u8),
+    /// Set global volume at xy (between 0 and 0x40)
+    GlobalVolume(u8),
+    /// Raise global volume by x or lower by y on each tick but the first
+    GlobalVolSlide(u8, u8),
+    /// Trigger Note Off after xy ticks
+    KeyOff(u8),
+    /// Same as vibrato, but depth is 4 times finer
+    FineVibrato(u8, u8),
+    /// Modulate panning at a speed of x steps (of 64) *PER ROW* and depth y
+    Panbrello(u8, u8),
+    /// (XM only) Super command, with x the subcommand and y the parameter.
+    XFinePortaUpDown(u8, u8),
+    /// Slide panning position right by x or left by y on each tick but the first
+    ///
+    /// Depending on format and settings, it could also be apply on the first tick only or on every tick.
+    PanningSlide(u8, u8),
+    /// Sets the volume envelope position to xy ticks
+    SetEnvPosition(u8),
+    /// Execute a midi macro
+    Midi(u8),
+    /// Execute an interpolated midi macro
+    SmoothMidi(u8),
+    /// Delay note for x ticks and cut after another y ticks.
+    ///
+    /// If the row ends before either effect is applied (speed is greater than x or x+y), that effect won't be applied.
+    DelayCut(u8, u8),
+    /// Combines the parameter value with the one on the row above it
+    XParam(u8),
+    NoteSlideUp(u8, u8),
+    NoteSlideDown(u8, u8),
+    NoteSlideUpRetrig(u8, u8),
+    NoteSlideDownRetrig(u8, u8),
+    ReverseOffset(u8),
+    // x : chns, y: enable
+    DBMEcho(u8, u8),
+    OffsetPercentage(u8),
 }

--- a/src/module/ctls.rs
+++ b/src/module/ctls.rs
@@ -1,362 +1,374 @@
 //! Definitions for all types and methods used to set and query
 //! libopenmpt parameters for the loaded module
 
-use openmpt_sys;
 use super::Module;
-use std::str::FromStr;
+use openmpt_sys;
 use std::os::raw::*;
+use std::str::FromStr;
 
-const LOAD_SKIP_SAMPLES:&str = "load.skip_samples";
-const LOAD_SKIP_PATTERNS:&str = "load.skip_patterns";
-const LOAD_SKIP_PLUGINS:&str = "load.skip_plugins";
-const LOAD_SKIP_SUBSONGS_INIT:&str = "load.skip_subsongs_init";
-const SEEK_SYNC_SAMPLES:&str = "seek.sync_samples";
-const PLAY_TEMPO_FACTOR:&str = "play.tempo_factor";
-const PLAY_PITCH_FACTOR:&str = "play.pitch_factor";
-const DITHER:&str = "dither";
+const LOAD_SKIP_SAMPLES: &str = "load.skip_samples";
+const LOAD_SKIP_PATTERNS: &str = "load.skip_patterns";
+const LOAD_SKIP_PLUGINS: &str = "load.skip_plugins";
+const LOAD_SKIP_SUBSONGS_INIT: &str = "load.skip_subsongs_init";
+const SEEK_SYNC_SAMPLES: &str = "seek.sync_samples";
+const PLAY_TEMPO_FACTOR: &str = "play.tempo_factor";
+const PLAY_PITCH_FACTOR: &str = "play.pitch_factor";
+const DITHER: &str = "dither";
 
 #[derive(PartialEq, Debug)]
 pub enum DitherMode {
-	/// Default mode. Chosen by OpenMPT code, might change.
-	Auto,
-	/// Rectangular, 0.5 bit depth, no noise shaping (original ModPlug Tracker).
-	ModPlug,
-	/// Rectangular, 1 bit depth, simple 1st order noise shaping
-	Simple,
-	/// No dithering.
-	None,
+    /// Default mode. Chosen by OpenMPT code, might change.
+    Auto,
+    /// Rectangular, 0.5 bit depth, no noise shaping (original ModPlug Tracker).
+    ModPlug,
+    /// Rectangular, 1 bit depth, simple 1st order noise shaping
+    Simple,
+    /// No dithering.
+    None,
 }
 
 impl FromStr for DitherMode {
-	type Err = &'static str;
+    type Err = &'static str;
 
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		match s {
-			"0" => Ok(DitherMode::None),
-			"1" => Ok(DitherMode::Auto),
-			"2" => Ok(DitherMode::ModPlug),
-			"3" => Ok(DitherMode::Simple),
-			_ => Err("Failed to parse return value as known Dither Mode")
-		}
-	}
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0" => Ok(DitherMode::None),
+            "1" => Ok(DitherMode::Auto),
+            "2" => Ok(DitherMode::ModPlug),
+            "3" => Ok(DitherMode::Simple),
+            _ => Err("Failed to parse return value as known Dither Mode"),
+        }
+    }
 }
 
 /// Ctls to use with `create`, `create_from_memory`, and
 /// `could_open_propability` in lists of initial ctls.
 pub enum Ctl {
-	/// Set to `true` to avoid loading samples into memory
-	SkipLoadingSamples(bool),
-	/// Set to `true` to avoid loading patterns into memory
-	SkipLoadingPatterns(bool),
-	/// Set to `true` to avoid loading plugins
-	SkipLoadingPlugins(bool),
-	/// Set to `true` to avoid pre-initializing sub-songs.
-	///
-	/// Skipping results in faster module loading but slower seeking.
-	SkipSubsongPreinit(bool),
-	/// Set to `true` to sync sample playback when using
-	/// `set_position_seconds` or `set_position_order_row`.
-	SyncSamplesWhenSeeking(bool),
-	/// Set a floating point tempo factor. 1.0 is the default tempo.
-	PlaybackTempoFactor(c_double),
-	/// Set a floating point pitch factor. 1.0 is the default pitch.
-	PlaybackPitchFactor(c_double),
-	/// Set the dither algorithm that is used for the 16 bit versions of the rendering methods.
-	DitherMode16Bit(DitherMode),
+    /// Set to `true` to avoid loading samples into memory
+    SkipLoadingSamples(bool),
+    /// Set to `true` to avoid loading patterns into memory
+    SkipLoadingPatterns(bool),
+    /// Set to `true` to avoid loading plugins
+    SkipLoadingPlugins(bool),
+    /// Set to `true` to avoid pre-initializing sub-songs.
+    ///
+    /// Skipping results in faster module loading but slower seeking.
+    SkipSubsongPreinit(bool),
+    /// Set to `true` to sync sample playback when using
+    /// `set_position_seconds` or `set_position_order_row`.
+    SyncSamplesWhenSeeking(bool),
+    /// Set a floating point tempo factor. 1.0 is the default tempo.
+    PlaybackTempoFactor(c_double),
+    /// Set a floating point pitch factor. 1.0 is the default pitch.
+    PlaybackPitchFactor(c_double),
+    /// Set the dither algorithm that is used for the 16 bit versions of the rendering methods.
+    DitherMode16Bit(DitherMode),
 }
 
 impl Ctl {
-	fn key_to_str(&self) -> String {
-		match *self {
-			Ctl::SkipLoadingSamples(_) =>  LOAD_SKIP_SAMPLES,
-			Ctl::SkipLoadingPatterns(_) => LOAD_SKIP_PATTERNS,
-			Ctl::SkipLoadingPlugins(_) => LOAD_SKIP_PLUGINS,
-			Ctl::SkipSubsongPreinit(_) => LOAD_SKIP_SUBSONGS_INIT,
-			Ctl::SyncSamplesWhenSeeking(_) => SEEK_SYNC_SAMPLES,
-			Ctl::PlaybackTempoFactor(_) => PLAY_TEMPO_FACTOR,
-			Ctl::PlaybackPitchFactor(_) => PLAY_PITCH_FACTOR,
-			Ctl::DitherMode16Bit(_) => DITHER,
-		}.to_owned()
-	}
+    fn key_to_str(&self) -> String {
+        match *self {
+            Ctl::SkipLoadingSamples(_) => LOAD_SKIP_SAMPLES,
+            Ctl::SkipLoadingPatterns(_) => LOAD_SKIP_PATTERNS,
+            Ctl::SkipLoadingPlugins(_) => LOAD_SKIP_PLUGINS,
+            Ctl::SkipSubsongPreinit(_) => LOAD_SKIP_SUBSONGS_INIT,
+            Ctl::SyncSamplesWhenSeeking(_) => SEEK_SYNC_SAMPLES,
+            Ctl::PlaybackTempoFactor(_) => PLAY_TEMPO_FACTOR,
+            Ctl::PlaybackPitchFactor(_) => PLAY_PITCH_FACTOR,
+            Ctl::DitherMode16Bit(_) => DITHER,
+        }
+        .to_owned()
+    }
 
-	fn param_to_str(&self) -> String {
-		use self::Ctl::*;
-		match *self {
-			SkipLoadingSamples(ref param) =>  if *param {"1"} else {"0"}.to_owned(),
-			SkipLoadingPatterns(ref param) => if *param {"1"} else {"0"}.to_owned(),
-			SkipLoadingPlugins(ref param) => if *param {"1"} else {"0"}.to_owned(),
-			SkipSubsongPreinit(ref param) => if *param {"1"} else {"0"}.to_owned(),
-			SyncSamplesWhenSeeking(ref param) => if *param {"1"} else {"0"}.to_owned(),
-			PlaybackTempoFactor(ref param) => param.to_string(),
-			PlaybackPitchFactor(ref param) => param.to_string(),
-			DitherMode16Bit(ref param) => match *param {
-				DitherMode::None => "0",
-				DitherMode::Auto => "1",
-				DitherMode::ModPlug => "2",
-				DitherMode::Simple => "3",
-			}.to_owned(),
-		}
-	}
+    fn param_to_str(&self) -> String {
+        use self::Ctl::*;
+        match *self {
+            SkipLoadingSamples(ref param) => if *param { "1" } else { "0" }.to_owned(),
+            SkipLoadingPatterns(ref param) => if *param { "1" } else { "0" }.to_owned(),
+            SkipLoadingPlugins(ref param) => if *param { "1" } else { "0" }.to_owned(),
+            SkipSubsongPreinit(ref param) => if *param { "1" } else { "0" }.to_owned(),
+            SyncSamplesWhenSeeking(ref param) => if *param { "1" } else { "0" }.to_owned(),
+            PlaybackTempoFactor(ref param) => param.to_string(),
+            PlaybackPitchFactor(ref param) => param.to_string(),
+            DitherMode16Bit(ref param) => match *param {
+                DitherMode::None => "0",
+                DitherMode::Auto => "1",
+                DitherMode::ModPlug => "2",
+                DitherMode::Simple => "3",
+            }
+            .to_owned(),
+        }
+    }
 }
 
 impl Module {
-	/// Get whether or not to avoid loading samples into memory.
-	pub fn ctl_get_load_skip_samples(&mut self) -> Option<bool> {
-		let return_val = self.ctl_get(LOAD_SKIP_SAMPLES);
+    /// Get whether or not to avoid loading samples into memory.
+    pub fn ctl_get_load_skip_samples(&mut self) -> Option<bool> {
+        let return_val = self.ctl_get(LOAD_SKIP_SAMPLES);
 
-		if let Some(ref str_val) = return_val {
-			i32::from_str(str_val).map(|num| num != 0).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            i32::from_str(str_val).map(|num| num != 0).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set whether or not to avoid loading samples into memory.
-	pub fn ctl_set_load_skip_samples(&mut self, value: bool) -> bool {
-		self.enum_ctl_set(&Ctl::SkipLoadingSamples(value))
-	}
+    /// Set whether or not to avoid loading samples into memory.
+    pub fn ctl_set_load_skip_samples(&mut self, value: bool) -> bool {
+        self.enum_ctl_set(&Ctl::SkipLoadingSamples(value))
+    }
 
-	/// Get whether or not to avoid loading patterns into memory.
-	pub fn ctl_get_load_skip_patterns(&mut self) -> Option<bool> {
-		let return_val = self.ctl_get(LOAD_SKIP_PATTERNS);
+    /// Get whether or not to avoid loading patterns into memory.
+    pub fn ctl_get_load_skip_patterns(&mut self) -> Option<bool> {
+        let return_val = self.ctl_get(LOAD_SKIP_PATTERNS);
 
-		if let Some(ref str_val) = return_val {
-			i32::from_str(str_val).map(|num| num != 0).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            i32::from_str(str_val).map(|num| num != 0).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set whether or not to avoid loading patterns into memory.
-	pub fn ctl_set_load_skip_patterns(&mut self, value: bool) -> bool {
-		self.enum_ctl_set(&Ctl::SkipLoadingPatterns(value))
-	}
+    /// Set whether or not to avoid loading patterns into memory.
+    pub fn ctl_set_load_skip_patterns(&mut self, value: bool) -> bool {
+        self.enum_ctl_set(&Ctl::SkipLoadingPatterns(value))
+    }
 
-	/// Get whether or not to avoid loading plugins.
-	pub fn ctl_get_load_skip_plugins(&mut self) -> Option<bool> {
-		let return_val = self.ctl_get(LOAD_SKIP_PLUGINS);
+    /// Get whether or not to avoid loading plugins.
+    pub fn ctl_get_load_skip_plugins(&mut self) -> Option<bool> {
+        let return_val = self.ctl_get(LOAD_SKIP_PLUGINS);
 
-		if let Some(ref str_val) = return_val {
-			i32::from_str(str_val).map(|num| num != 0).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            i32::from_str(str_val).map(|num| num != 0).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set whether or not to avoid loading plugins.
-	pub fn ctl_set_load_skip_plugins(&mut self, value: bool) -> bool {
-		self.enum_ctl_set(&Ctl::SkipLoadingPlugins(value))
-	}
+    /// Set whether or not to avoid loading plugins.
+    pub fn ctl_set_load_skip_plugins(&mut self, value: bool) -> bool {
+        self.enum_ctl_set(&Ctl::SkipLoadingPlugins(value))
+    }
 
-	/// Get whether or not to avoid pre-initializing sub-songs.
-	pub fn ctl_get_load_skip_subsongs_init(&mut self) -> Option<bool> {
-		let return_val = self.ctl_get(LOAD_SKIP_SUBSONGS_INIT);
+    /// Get whether or not to avoid pre-initializing sub-songs.
+    pub fn ctl_get_load_skip_subsongs_init(&mut self) -> Option<bool> {
+        let return_val = self.ctl_get(LOAD_SKIP_SUBSONGS_INIT);
 
-		if let Some(ref str_val) = return_val {
-			i32::from_str(str_val).map(|num| num != 0).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            i32::from_str(str_val).map(|num| num != 0).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set whether or not to avoid pre-initializing sub-songs.
-	pub fn ctl_set_load_skip_subsongs_init(&mut self, value: bool) -> bool {
-		self.enum_ctl_set(&Ctl::SkipSubsongPreinit(value))
-	}
+    /// Set whether or not to avoid pre-initializing sub-songs.
+    pub fn ctl_set_load_skip_subsongs_init(&mut self, value: bool) -> bool {
+        self.enum_ctl_set(&Ctl::SkipSubsongPreinit(value))
+    }
 
-	/// Get whether or not to sync sample playback when seeking.
-	pub fn ctl_get_seek_sync_samples(&mut self) -> Option<bool> {
-		let return_val = self.ctl_get(SEEK_SYNC_SAMPLES);
+    /// Get whether or not to sync sample playback when seeking.
+    pub fn ctl_get_seek_sync_samples(&mut self) -> Option<bool> {
+        let return_val = self.ctl_get(SEEK_SYNC_SAMPLES);
 
-		if let Some(ref str_val) = return_val {
-			i32::from_str(str_val).map(|num| num != 0).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            i32::from_str(str_val).map(|num| num != 0).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set whether or not to sync sample playback when seeking.
-	pub fn ctl_set_seek_sync_samples(&mut self, value: bool) -> bool {
-		self.enum_ctl_set(&Ctl::SyncSamplesWhenSeeking(value))
-	}
+    /// Set whether or not to sync sample playback when seeking.
+    pub fn ctl_set_seek_sync_samples(&mut self, value: bool) -> bool {
+        self.enum_ctl_set(&Ctl::SyncSamplesWhenSeeking(value))
+    }
 
-	/// Get the floating point tempo factor.
-	pub fn ctl_get_play_tempo_factor(&mut self) -> Option<c_double> {
-		let return_val = self.ctl_get(PLAY_TEMPO_FACTOR);
+    /// Get the floating point tempo factor.
+    pub fn ctl_get_play_tempo_factor(&mut self) -> Option<c_double> {
+        let return_val = self.ctl_get(PLAY_TEMPO_FACTOR);
 
-		if let Some(ref str_val) = return_val {
-			c_double::from_str(str_val).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            c_double::from_str(str_val).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set a floating point tempo factor.
-	pub fn ctl_set_play_tempo_factor(&mut self, value: c_double) -> bool {
-		self.enum_ctl_set(&Ctl::PlaybackTempoFactor(value))
-	}
+    /// Set a floating point tempo factor.
+    pub fn ctl_set_play_tempo_factor(&mut self, value: c_double) -> bool {
+        self.enum_ctl_set(&Ctl::PlaybackTempoFactor(value))
+    }
 
-	/// Get the floating point pitch factor.
-	pub fn ctl_get_play_pitch_factor(&mut self) -> Option<c_double> {
-		let return_val = self.ctl_get(PLAY_PITCH_FACTOR);
+    /// Get the floating point pitch factor.
+    pub fn ctl_get_play_pitch_factor(&mut self) -> Option<c_double> {
+        let return_val = self.ctl_get(PLAY_PITCH_FACTOR);
 
-		if let Some(ref str_val) = return_val {
-			c_double::from_str(str_val).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            c_double::from_str(str_val).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set a floating point pitch factor
-	pub fn ctl_set_play_pitch_factor(&mut self, value: c_double) -> bool {
-		self.enum_ctl_set(&Ctl::PlaybackPitchFactor(value))
-	}
+    /// Set a floating point pitch factor
+    pub fn ctl_set_play_pitch_factor(&mut self, value: c_double) -> bool {
+        self.enum_ctl_set(&Ctl::PlaybackPitchFactor(value))
+    }
 
-	/// Get the dither algorithm that is used for the 16 bit versions of the rendering methods.
-	pub fn ctl_get_dither(&mut self) -> Option<DitherMode> {
-		let return_val = self.ctl_get(DITHER);
+    /// Get the dither algorithm that is used for the 16 bit versions of the rendering methods.
+    pub fn ctl_get_dither(&mut self) -> Option<DitherMode> {
+        let return_val = self.ctl_get(DITHER);
 
-		if let Some(ref str_val) = return_val {
-			DitherMode::from_str(str_val).ok()
-		} else {
-			None
-		}
-	}
+        if let Some(ref str_val) = return_val {
+            DitherMode::from_str(str_val).ok()
+        } else {
+            None
+        }
+    }
 
-	/// Set the dither algorithm that is used for the 16 bit versions of the rendering methods.
-	pub fn ctl_set_dither(&mut self, value: DitherMode) -> bool {
-		self.enum_ctl_set(&Ctl::DitherMode16Bit(value))
-	}
+    /// Set the dither algorithm that is used for the 16 bit versions of the rendering methods.
+    pub fn ctl_set_dither(&mut self, value: DitherMode) -> bool {
+        self.enum_ctl_set(&Ctl::DitherMode16Bit(value))
+    }
 
-	/// Get ctl value directly, as a string.
-	/// 
-	/// ### Parameters
-	/// * `ctl` : The ctl key whose value should be retrieved.
-	///
-	/// ### Returns
-	/// The associated ctl value, or None on failure.
-	pub fn ctl_get(&mut self, key: &str) -> Option<String> {
-		get_string_with_string!(key, {
-			openmpt_sys::openmpt_module_ctl_get(self.inner, key)
-		})
-	}
+    /// Get ctl value directly, as a string.
+    ///
+    /// ### Parameters
+    /// * `ctl` : The ctl key whose value should be retrieved.
+    ///
+    /// ### Returns
+    /// The associated ctl value, or None on failure.
+    pub fn ctl_get(&mut self, key: &str) -> Option<String> {
+        get_string_with_string!(key, {
+            openmpt_sys::openmpt_module_ctl_get(self.inner, key)
+        })
+    }
 
-	pub(super) fn enum_ctl_set(&mut self, ctl: &Ctl) -> bool {
-		let key = ctl.key_to_str();
-		let val = ctl.param_to_str();
+    pub(super) fn enum_ctl_set(&mut self, ctl: &Ctl) -> bool {
+        let key = ctl.key_to_str();
+        let val = ctl.param_to_str();
 
-		self.ctl_set(&key, &val)
-	}
+        self.ctl_set(&key, &val)
+    }
 
-	/// Set ctl value directly, using strings.
-	/// 
-	/// ### Parameters
-	/// * `ctl` : The ctl key whose value should be set.
-	/// * `value` : The value that should be set.
-	///
-	/// ### Returns
-	/// Whether or not the operation has succeded.
-	pub fn ctl_set(&mut self, key: &str, val: &str) -> bool {
-		let return_value = with_2strings!(key, val, {
-			openmpt_sys::openmpt_module_ctl_set(self.inner, key, val)
-		});
+    /// Set ctl value directly, using strings.
+    ///
+    /// ### Parameters
+    /// * `ctl` : The ctl key whose value should be set.
+    /// * `value` : The value that should be set.
+    ///
+    /// ### Returns
+    /// Whether or not the operation has succeded.
+    pub fn ctl_set(&mut self, key: &str, val: &str) -> bool {
+        let return_value = with_2strings!(key, val, {
+            openmpt_sys::openmpt_module_ctl_set(self.inner, key, val)
+        });
 
-		if return_value == 1 { true } else { false }
-	}
+        return_value == 1
+    }
 
-	/// Retrieve supported ctl keys.
-	///
-	/// ### Returns
-	/// A semicolon-separated list containing all supported ctl keys.
-	pub fn get_ctls(&mut self) -> String {
-		let opt_string = get_string! {
-			openmpt_sys::openmpt_module_get_ctls(self.inner)
-		};
+    /// Retrieve supported ctl keys.
+    ///
+    /// ### Returns
+    /// A semicolon-separated list containing all supported ctl keys.
+    pub fn get_ctls(&mut self) -> String {
+        let opt_string = get_string! {
+            openmpt_sys::openmpt_module_get_ctls(self.inner)
+        };
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use super::super::Module;
-	use super::super::Logger;
-	use super::super::test_helper;
+    use super::super::test_helper;
+    use super::super::Logger;
+    use super::super::Module;
+    use super::*;
 
-	#[test]
-	fn all_known_ctls_are_supported() {
-		let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
-		let keys = module.get_ctls();
-		
-		assert!(keys.contains(LOAD_SKIP_SAMPLES));
-		assert!(keys.contains(LOAD_SKIP_PATTERNS));
-		assert!(keys.contains(LOAD_SKIP_PLUGINS));
-		assert!(keys.contains(LOAD_SKIP_SUBSONGS_INIT));
-		assert!(keys.contains(SEEK_SYNC_SAMPLES));
-		assert!(keys.contains(PLAY_TEMPO_FACTOR));
-		assert!(keys.contains(PLAY_PITCH_FACTOR));
-		assert!(keys.contains(DITHER));
-	}
+    #[test]
+    fn all_known_ctls_are_supported() {
+        let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
+        let keys = module.get_ctls();
 
-	#[test]
-	fn default_ctls_are_respected() {
-		let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
-		
-		assert_eq!(module.ctl_get_load_skip_samples().unwrap(), false);
-		assert_eq!(module.ctl_get_load_skip_patterns().unwrap(), false);
-		assert_eq!(module.ctl_get_load_skip_plugins().unwrap(), false);
-		assert_eq!(module.ctl_get_load_skip_subsongs_init().unwrap(), false);
-		assert_eq!(module.ctl_get_seek_sync_samples().unwrap(), false);
-		assert_eq!(module.ctl_get_play_tempo_factor().unwrap(), 1.0);
-		assert_eq!(module.ctl_get_play_pitch_factor().unwrap(), 1.0);
-		assert_eq!(module.ctl_get_dither().unwrap(), DitherMode::Auto);
-	}
+        assert!(keys.contains(LOAD_SKIP_SAMPLES));
+        assert!(keys.contains(LOAD_SKIP_PATTERNS));
+        assert!(keys.contains(LOAD_SKIP_PLUGINS));
+        assert!(keys.contains(LOAD_SKIP_SUBSONGS_INIT));
+        assert!(keys.contains(SEEK_SYNC_SAMPLES));
+        assert!(keys.contains(PLAY_TEMPO_FACTOR));
+        assert!(keys.contains(PLAY_PITCH_FACTOR));
+        assert!(keys.contains(DITHER));
+    }
 
-	#[test]
-	fn initial_ctls_are_respected() {
-		let initial_ctls = vec!{
-			Ctl::SkipLoadingSamples(true),
-			Ctl::SkipLoadingPatterns(true),
-			Ctl::SkipLoadingPlugins(true),
-			Ctl::SkipSubsongPreinit(true),
-			Ctl::SyncSamplesWhenSeeking(true),
-			Ctl::PlaybackTempoFactor(2.0),
-			Ctl::PlaybackPitchFactor(2.0),
-			Ctl::DitherMode16Bit(DitherMode::Simple),
-		};
+    #[test]
+    fn default_ctls_are_respected() {
+        let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
 
-		let mut module = test_helper::load_file_as_module_with_ctls("empty_module.xm", Logger::None, &initial_ctls).unwrap();
-		
-		assert_eq!(module.ctl_get_load_skip_samples().unwrap(), true);
-		assert_eq!(module.ctl_get_load_skip_patterns().unwrap(), true);
-		assert_eq!(module.ctl_get_load_skip_plugins().unwrap(), true);
-		assert_eq!(module.ctl_get_load_skip_subsongs_init().unwrap(), true);
-		assert_eq!(module.ctl_get_seek_sync_samples().unwrap(), true);
-		assert_eq!(module.ctl_get_play_tempo_factor().unwrap(), 2.0);
-		assert_eq!(module.ctl_get_play_pitch_factor().unwrap(), 2.0);
-		assert_eq!(module.ctl_get_dither().unwrap(), DitherMode::Simple);
-	}
+        assert_eq!(module.ctl_get_load_skip_samples().unwrap(), false);
+        assert_eq!(module.ctl_get_load_skip_patterns().unwrap(), false);
+        assert_eq!(module.ctl_get_load_skip_plugins().unwrap(), false);
+        assert_eq!(module.ctl_get_load_skip_subsongs_init().unwrap(), false);
+        assert_eq!(module.ctl_get_seek_sync_samples().unwrap(), false);
+        assert_eq!(module.ctl_get_play_tempo_factor().unwrap(), 1.0);
+        assert_eq!(module.ctl_get_play_pitch_factor().unwrap(), 1.0);
+        assert_eq!(module.ctl_get_dither().unwrap(), DitherMode::Auto);
+    }
 
-	#[test]
-	fn clean_result_for_getting_unknown_ctl() {
-		let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
+    #[test]
+    fn initial_ctls_are_respected() {
+        let initial_ctls = vec![
+            Ctl::SkipLoadingSamples(true),
+            Ctl::SkipLoadingPatterns(true),
+            Ctl::SkipLoadingPlugins(true),
+            Ctl::SkipSubsongPreinit(true),
+            Ctl::SyncSamplesWhenSeeking(true),
+            Ctl::PlaybackTempoFactor(2.0),
+            Ctl::PlaybackPitchFactor(2.0),
+            Ctl::DitherMode16Bit(DitherMode::Simple),
+        ];
 
-		assert!(module.ctl_get("invalid_ctl").is_none());
-	}
+        let mut module = test_helper::load_file_as_module_with_ctls(
+            "empty_module.xm",
+            Logger::None,
+            &initial_ctls,
+        )
+        .unwrap();
 
-	#[test]
-	fn clean_result_for_setting_invalid_ctl() {
-		let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
+        assert_eq!(module.ctl_get_load_skip_samples().unwrap(), true);
+        assert_eq!(module.ctl_get_load_skip_patterns().unwrap(), true);
+        assert_eq!(module.ctl_get_load_skip_plugins().unwrap(), true);
+        assert_eq!(module.ctl_get_load_skip_subsongs_init().unwrap(), true);
+        assert_eq!(module.ctl_get_seek_sync_samples().unwrap(), true);
+        assert_eq!(module.ctl_get_play_tempo_factor().unwrap(), 2.0);
+        assert_eq!(module.ctl_get_play_pitch_factor().unwrap(), 2.0);
+        assert_eq!(module.ctl_get_dither().unwrap(), DitherMode::Simple);
+    }
 
-		try_set_ctl(&mut module, DITHER, "26");
-	}
+    #[test]
+    fn clean_result_for_getting_unknown_ctl() {
+        let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
 
-	fn try_set_ctl (module: &mut Module, key: &str, new_val: &str) {
-		// Apparently, those only return false if the string pointers are invalid.
-		// assert!(!module.ctl_set(dither, "26"));
+        assert!(module.ctl_get("invalid_ctl").is_none());
+    }
 
-		module.ctl_set(key, "26");
-		println!("Tried setting {:?} at {:?}, now at {:?}", key, new_val, module.ctl_get(DITHER).unwrap());
-	}
+    #[test]
+    fn clean_result_for_setting_invalid_ctl() {
+        let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
+
+        try_set_ctl(&mut module, DITHER, "26");
+    }
+
+    fn try_set_ctl(module: &mut Module, key: &str, new_val: &str) {
+        // Apparently, those only return false if the string pointers are invalid.
+        // assert!(!module.ctl_set(dither, "26"));
+
+        module.ctl_set(key, "26");
+        println!(
+            "Tried setting {:?} at {:?}, now at {:?}",
+            key,
+            new_val,
+            module.ctl_get(DITHER).unwrap()
+        );
+    }
 }

--- a/src/module/current.rs
+++ b/src/module/current.rs
@@ -6,238 +6,211 @@ use openmpt_sys;
 use std::os::raw::*;
 
 impl Module {
-	/// Select a sub-song from a multi-song module.
-	/// 
-	/// ### Parameters
-	/// * `subsong_num` : Index of the sub-song. -1 plays all sub-songs consecutively.
-	///
-	/// ### Returns
-	/// Whether or not the operation has succeded.
-	///
-	/// ### Remarks
-	/// Whether subsong -1 (all subsongs consecutively), subsong 0 or some other subsong
-	/// is selected by default, is an implementation detail and subject to change.
-	/// If you do not want to care about subsongs, it is recommended to just not call this method at all.
-	pub fn select_subsong(&mut self, subsong_num: i32) -> bool {
-		let return_code = unsafe {
-			openmpt_sys::openmpt_module_select_subsong(self.inner, subsong_num)
-		};
+    /// Select a sub-song from a multi-song module.
+    ///
+    /// ### Parameters
+    /// * `subsong_num` : Index of the sub-song. -1 plays all sub-songs consecutively.
+    ///
+    /// ### Returns
+    /// Whether or not the operation has succeded.
+    ///
+    /// ### Remarks
+    /// Whether subsong -1 (all subsongs consecutively), subsong 0 or some other subsong
+    /// is selected by default, is an implementation detail and subject to change.
+    /// If you do not want to care about subsongs, it is recommended to just not call this method at all.
+    pub fn select_subsong(&mut self, subsong_num: i32) -> bool {
+        let return_code =
+            unsafe { openmpt_sys::openmpt_module_select_subsong(self.inner, subsong_num) };
 
-		if return_code == 0 { false } else { true }
-	}
+        return_code != 0
+    }
 
-	/// Set approximate current song position.
-	///
-	/// ### Parameters
-	/// * `seconds` : Seconds to seek to.
-	///
-	/// ### Returns
-	/// Approximate new song position in seconds.
-	///
-	/// ### Remarks
-	/// If seconds is out of range, the position gets set to song start or end respectively.
-	pub fn set_position_seconds(&mut self, seconds: c_double) -> c_double {
-		// Never fails, will set position to begining or end of the song of out of range
-		unsafe {
-			openmpt_sys::openmpt_module_set_position_seconds(self.inner, seconds)
-		}
-	}
+    /// Set approximate current song position.
+    ///
+    /// ### Parameters
+    /// * `seconds` : Seconds to seek to.
+    ///
+    /// ### Returns
+    /// Approximate new song position in seconds.
+    ///
+    /// ### Remarks
+    /// If seconds is out of range, the position gets set to song start or end respectively.
+    pub fn set_position_seconds(&mut self, seconds: c_double) -> c_double {
+        // Never fails, will set position to begining or end of the song of out of range
+        unsafe { openmpt_sys::openmpt_module_set_position_seconds(self.inner, seconds) }
+    }
 
-	/// Set approximate current song position.
-	///
-	/// ### Parameters
-	/// * `order` : Pattern order number to seek to.
-	/// * `row` : Pattern row number to seek to.
-	///
-	/// ### Returns
-	/// Approximate new song position in seconds.
-	///
-	/// ### Remarks
-	/// If order or row are out of range, to position is not modified and the current position is returned.
-	pub fn set_position_order_row(&mut self, order: i32, row: i32) -> c_double {
-		// Returns current position on failure
-		unsafe {
-			openmpt_sys::openmpt_module_set_position_order_row(self.inner, order, row)
-		}
-	}
+    /// Set approximate current song position.
+    ///
+    /// ### Parameters
+    /// * `order` : Pattern order number to seek to.
+    /// * `row` : Pattern row number to seek to.
+    ///
+    /// ### Returns
+    /// Approximate new song position in seconds.
+    ///
+    /// ### Remarks
+    /// If order or row are out of range, to position is not modified and the current position is returned.
+    pub fn set_position_order_row(&mut self, order: i32, row: i32) -> c_double {
+        // Returns current position on failure
+        unsafe { openmpt_sys::openmpt_module_set_position_order_row(self.inner, order, row) }
+    }
 
-	/// Get current song position.
-	///
-	/// ### Returns
-	/// Current song position in seconds.
-	pub fn get_position_seconds(&mut self) -> c_double {
-		unsafe {
-			openmpt_sys::openmpt_module_get_position_seconds(self.inner)
-		}
-	}
+    /// Get current song position.
+    ///
+    /// ### Returns
+    /// Current song position in seconds.
+    pub fn get_position_seconds(&mut self) -> c_double {
+        unsafe { openmpt_sys::openmpt_module_get_position_seconds(self.inner) }
+    }
 
-	/// Get the current order.
-	///
-	/// ### Returns
-	/// The current order at which the module is being played back.
-	pub fn get_current_order(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_order(self.inner)
-		}
-	}
+    /// Get the current order.
+    ///
+    /// ### Returns
+    /// The current order at which the module is being played back.
+    pub fn get_current_order(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_current_order(self.inner) }
+    }
 
-	/// Get the current pattern.
-	///
-	/// ### Returns
-	/// The current pattern that is being played.
-	pub fn get_current_pattern(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_pattern(self.inner)
-		}
-	}
+    /// Get the current pattern.
+    ///
+    /// ### Returns
+    /// The current pattern that is being played.
+    pub fn get_current_pattern(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_current_pattern(self.inner) }
+    }
 
-	/// Get the current row.
-	///
-	/// ### Returns
-	/// The current row at which the current pattern is being played.
-	pub fn get_current_row(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_row(self.inner)
-		}
-	}
+    /// Get the current row.
+    ///
+    /// ### Returns
+    /// The current row at which the current pattern is being played.
+    pub fn get_current_row(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_current_row(self.inner) }
+    }
 
-	/// Get the current speed.
-	///
-	/// ### Returns
-	/// The current speed in ticks per row.
-	pub fn get_current_speed(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_speed(self.inner)
-		}
-	}
+    /// Get the current speed.
+    ///
+    /// ### Returns
+    /// The current speed in ticks per row.
+    pub fn get_current_speed(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_current_speed(self.inner) }
+    }
 
-	/// Get the current tempo.
-	///
-	/// ### Returns
-	/// The current tempo in tracker units. The exact meaning of this value depends on the tempo mode being used.
-	pub fn get_current_tempo(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_tempo(self.inner)
-		}
-	}
+    /// Get the current tempo.
+    ///
+    /// ### Returns
+    /// The current tempo in tracker units. The exact meaning of this value depends on the tempo mode being used.
+    pub fn get_current_tempo(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_current_tempo(self.inner) }
+    }
 
-	/// Get the current amount of playing channels.
-	///
-	/// ### Returns
-	/// The amount of sample channels that are currently being rendered.
-	pub fn get_current_playing_channels(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_playing_channels(self.inner)
-		}
-	}
+    /// Get the current amount of playing channels.
+    ///
+    /// ### Returns
+    /// The amount of sample channels that are currently being rendered.
+    pub fn get_current_playing_channels(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_current_playing_channels(self.inner) }
+    }
 
-	/// Get the approximate song duration.
-	///
-	/// ### Returns
-	/// Approximate duration of current sub-song in seconds.
-	pub fn get_duration_seconds(&mut self) -> c_double {
-		// Depends on the current subsong
-		unsafe {
-			openmpt_sys::openmpt_module_get_duration_seconds(self.inner)
-		}
-	}
+    /// Get the approximate song duration.
+    ///
+    /// ### Returns
+    /// Approximate duration of current sub-song in seconds.
+    pub fn get_duration_seconds(&mut self) -> c_double {
+        // Depends on the current subsong
+        unsafe { openmpt_sys::openmpt_module_get_duration_seconds(self.inner) }
+    }
 
-	/// Get an approximate indication of the channel volume.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The channel whose volume should be retrieved.
-	///
-	/// ### Returns
-	/// The approximate channel volume.
-	///
-	/// ### Remarks
-	/// The returned value is solely based on the note velocity and
-	/// does not take the actual waveform of the playing sample into account.
-	pub fn get_current_channel_vu_mono(&mut self, channel_num: i32) -> c_float {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_channel_vu_mono(self.inner, channel_num)
-		}
-	}
+    /// Get an approximate indication of the channel volume.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The channel whose volume should be retrieved.
+    ///
+    /// ### Returns
+    /// The approximate channel volume.
+    ///
+    /// ### Remarks
+    /// The returned value is solely based on the note velocity and
+    /// does not take the actual waveform of the playing sample into account.
+    pub fn get_current_channel_vu_mono(&mut self, channel_num: i32) -> c_float {
+        unsafe { openmpt_sys::openmpt_module_get_current_channel_vu_mono(self.inner, channel_num) }
+    }
 
-	/// Get an approximate indication of the channel volume on the front-left speaker.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The channel whose volume should be retrieved.
-	///
-	/// ### Returns
-	/// The approximate channel volume.
-	///
-	/// ### Remarks
-	/// The returned value is solely based on the note velocity and
-	/// does not take the actual waveform of the playing sample into account.
-	pub fn get_current_channel_vu_left(&mut self, channel_num: i32) -> c_float {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_channel_vu_left(self.inner, channel_num)
-		}
-	}
+    /// Get an approximate indication of the channel volume on the front-left speaker.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The channel whose volume should be retrieved.
+    ///
+    /// ### Returns
+    /// The approximate channel volume.
+    ///
+    /// ### Remarks
+    /// The returned value is solely based on the note velocity and
+    /// does not take the actual waveform of the playing sample into account.
+    pub fn get_current_channel_vu_left(&mut self, channel_num: i32) -> c_float {
+        unsafe { openmpt_sys::openmpt_module_get_current_channel_vu_left(self.inner, channel_num) }
+    }
 
-	/// Get an approximate indication of the channel volume on the front-right speaker.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The channel whose volume should be retrieved.
-	///
-	/// ### Returns
-	/// The approximate channel volume.
-	///
-	/// ### Remarks
-	/// The returned value is solely based on the note velocity and
-	/// does not take the actual waveform of the playing sample into account.
-	pub fn get_current_channel_vu_right(&mut self, channel_num: i32) -> c_float {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_channel_vu_right(self.inner, channel_num)
-		}
-	}
+    /// Get an approximate indication of the channel volume on the front-right speaker.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The channel whose volume should be retrieved.
+    ///
+    /// ### Returns
+    /// The approximate channel volume.
+    ///
+    /// ### Remarks
+    /// The returned value is solely based on the note velocity and
+    /// does not take the actual waveform of the playing sample into account.
+    pub fn get_current_channel_vu_right(&mut self, channel_num: i32) -> c_float {
+        unsafe { openmpt_sys::openmpt_module_get_current_channel_vu_right(self.inner, channel_num) }
+    }
 
-	/// Get an approximate indication of the channel volume on the rear-left speaker.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The channel whose volume should be retrieved.
-	///
-	/// ### Returns
-	/// The approximate channel volume.
-	///
-	/// ### Remarks
-	/// The returned value is solely based on the note velocity and
-	/// does not take the actual waveform of the playing sample into account.
-	pub fn get_current_channel_vu_rear_left(&mut self, channel_num: i32) -> c_float {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_channel_vu_rear_left(self.inner, channel_num)
-		}
-	}
+    /// Get an approximate indication of the channel volume on the rear-left speaker.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The channel whose volume should be retrieved.
+    ///
+    /// ### Returns
+    /// The approximate channel volume.
+    ///
+    /// ### Remarks
+    /// The returned value is solely based on the note velocity and
+    /// does not take the actual waveform of the playing sample into account.
+    pub fn get_current_channel_vu_rear_left(&mut self, channel_num: i32) -> c_float {
+        unsafe {
+            openmpt_sys::openmpt_module_get_current_channel_vu_rear_left(self.inner, channel_num)
+        }
+    }
 
-	/// Get an approximate indication of the channel volume on the rear-right speaker.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The channel whose volume should be retrieved.
-	///
-	/// ### Returns
-	/// The approximate channel volume.
-	///
-	/// ### Remarks
-	/// The returned value is solely based on the note velocity and
-	/// does not take the actual waveform of the playing sample into account.
-	pub fn get_current_channel_vu_rear_right(&mut self, channel_num: i32) -> c_float {
-		unsafe {
-			openmpt_sys::openmpt_module_get_current_channel_vu_rear_right(self.inner, channel_num)
-		}
-	}
+    /// Get an approximate indication of the channel volume on the rear-right speaker.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The channel whose volume should be retrieved.
+    ///
+    /// ### Returns
+    /// The approximate channel volume.
+    ///
+    /// ### Remarks
+    /// The returned value is solely based on the note velocity and
+    /// does not take the actual waveform of the playing sample into account.
+    pub fn get_current_channel_vu_rear_right(&mut self, channel_num: i32) -> c_float {
+        unsafe {
+            openmpt_sys::openmpt_module_get_current_channel_vu_rear_right(self.inner, channel_num)
+        }
+    }
 }
 
 // Tests
 
-	// #[test]
-	// fn unatco_can_change_subsong() {
-	// 	let mut module = test_helper::load_file_as_module("UNATCO.it").unwrap();
-	// 	let subsongs = module.get_subsongs();
+// #[test]
+// fn unatco_can_change_subsong() {
+// 	let mut module = test_helper::load_file_as_module("UNATCO.it").unwrap();
+// 	let subsongs = module.get_subsongs();
 
-	// 	assert_eq!(subsongs.len(), 5); // Main, Game over, Dialogue /w intro, Combat, Dialogue loop
-		
-	// 	for song in subsongs {
-	// 		assert!(module.select_subsong(&song));
-	// 	}
-	// }
+// 	assert_eq!(subsongs.len(), 5); // Main, Game over, Dialogue /w intro, Combat, Dialogue loop
+
+// 	for song in subsongs {
+// 		assert!(module.select_subsong(&song));
+// 	}
+// }

--- a/src/module/iteration.rs
+++ b/src/module/iteration.rs
@@ -1,468 +1,472 @@
 //! Definitions for all types and methods used to iterate
 //! on the module's pattern data
 
-use openmpt_sys;
-use super::Module;
 use super::super::mod_command::ModCommand;
+use super::Module;
+use openmpt_sys;
 use std::os::raw::c_int;
 
 pub struct Pattern<'m> {
-	module: &'m mut Module,
-	num: i32,
+    module: &'m mut Module,
+    num: i32,
 }
 
-pub struct Row<'p, 'm:'p> {
-	pattern: &'p mut Pattern<'m>,
-	num: i32,
+pub struct Row<'p, 'm: 'p> {
+    pattern: &'p mut Pattern<'m>,
+    num: i32,
 }
 
-pub struct Cell<'r, 'p:'r, 'm:'p> {
-	row: &'r mut Row<'p, 'm>,
-	channel_num: i32,
+pub struct Cell<'r, 'p: 'r, 'm: 'p> {
+    row: &'r mut Row<'p, 'm>,
+    channel_num: i32,
 }
 
 impl Module {
-	/// Get pattern at order position.
-	///
-	/// ### Parameters
-	/// * `order_num` : The position from which the pattern should be retrieved.
-	///
-	/// ### Returns
-	/// A Pattern wrapper for the pattern found at the given order position of the current sequence,
-	/// or None if no such pattern exists.
-	pub fn get_pattern_by_order(&mut self, order_num: i32) -> Option<Pattern> {
-		let pattern_num = unsafe {
-			openmpt_sys::openmpt_module_get_order_pattern(self.inner, order_num)
-		};
+    /// Get pattern at order position.
+    ///
+    /// ### Parameters
+    /// * `order_num` : The position from which the pattern should be retrieved.
+    ///
+    /// ### Returns
+    /// A Pattern wrapper for the pattern found at the given order position of the current sequence,
+    /// or None if no such pattern exists.
+    pub fn get_pattern_by_order(&mut self, order_num: i32) -> Option<Pattern> {
+        let pattern_num =
+            unsafe { openmpt_sys::openmpt_module_get_order_pattern(self.inner, order_num) };
 
-		if pattern_num < 0 {
-			None
-		} else {
-			Some(Pattern{ num : pattern_num, module: self })
-		}
-	}
+        if pattern_num < 0 {
+            None
+        } else {
+            Some(Pattern {
+                num: pattern_num,
+                module: self,
+            })
+        }
+    }
 
-	/// Get pattern by index.
-	///
-	/// ### Parameters
-	/// * `pattern_num` : The index of the pattern that should be retrieved.
-	///
-	/// ### Returns
-	/// A Pattern wrapper for the pattern, or None if no such pattern exists.
-	pub fn get_pattern_by_number (&mut self, pattern_num: i32) -> Option<Pattern> {
-		if pattern_num < 0 || pattern_num >= self.get_num_patterns() {
-			None
-		} else {
-			Some(Pattern{ num : pattern_num, module: self })
-		}
-	}
+    /// Get pattern by index.
+    ///
+    /// ### Parameters
+    /// * `pattern_num` : The index of the pattern that should be retrieved.
+    ///
+    /// ### Returns
+    /// A Pattern wrapper for the pattern, or None if no such pattern exists.
+    pub fn get_pattern_by_number(&mut self, pattern_num: i32) -> Option<Pattern> {
+        if pattern_num < 0 || pattern_num >= self.get_num_patterns() {
+            None
+        } else {
+            Some(Pattern {
+                num: pattern_num,
+                module: self,
+            })
+        }
+    }
 
-	/// Get the number of distinct patterns for that module.
-	///
-	/// ### Returns
-	/// The number of distinct patterns in the module.
-	pub fn get_num_patterns (&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_num_patterns(self.inner)
-		}
-	}
+    /// Get the number of distinct patterns for that module.
+    ///
+    /// ### Returns
+    /// The number of distinct patterns in the module.
+    pub fn get_num_patterns(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_num_patterns(self.inner) }
+    }
 
-	/// Get the length of the order sequence for that module.
-	///
-	/// ### Returns
-	/// The number of orders in the current sequence of the module.
-	pub fn get_num_orders (&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_num_orders(self.inner)
-		}
-	}
+    /// Get the length of the order sequence for that module.
+    ///
+    /// ### Returns
+    /// The number of orders in the current sequence of the module.
+    pub fn get_num_orders(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_num_orders(self.inner) }
+    }
 
-	/// Get the number of pattern channels.
-	///
-	/// ### Returns
-	/// The number of pattern channels in the module. Not all channels do necessarily contain data.
-	///
-	/// ### Remarks
-	/// The number of pattern channels is completely independent of the number of output channels.
-	pub fn get_num_channels (&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_num_channels(self.inner)
-		}
-	}
+    /// Get the number of pattern channels.
+    ///
+    /// ### Returns
+    /// The number of pattern channels in the module. Not all channels do necessarily contain data.
+    ///
+    /// ### Remarks
+    /// The number of pattern channels is completely independent of the number of output channels.
+    pub fn get_num_channels(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_num_channels(self.inner) }
+    }
 
-	/// Get the number of instruments.
-	///
-	/// ### Returns
-	/// The number of instrument slots in the module.
-	///
-	/// ### Remarks
-	/// Instruments are a layer on top of samples, and are not supported by all module formats.
-	pub fn get_num_instruments (&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_num_instruments(self.inner)
-		}
-	}
+    /// Get the number of instruments.
+    ///
+    /// ### Returns
+    /// The number of instrument slots in the module.
+    ///
+    /// ### Remarks
+    /// Instruments are a layer on top of samples, and are not supported by all module formats.
+    pub fn get_num_instruments(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_num_instruments(self.inner) }
+    }
 
-	/// Get the number of samples.
-	///
-	/// ### Returns
-	/// The number of sample slots in the module.
-	pub fn get_num_samples (&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_num_samples(self.inner)
-		}
-	}
+    /// Get the number of samples.
+    ///
+    /// ### Returns
+    /// The number of sample slots in the module.
+    pub fn get_num_samples(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_num_samples(self.inner) }
+    }
 
-	/// Get the number of sub-songs.
-	///
-	/// ### Returns
-	/// The number of sub-songs in the module.
-	/// 
-	/// This includes any "hidden" songs (songs that share the same sequence,
-	/// but start at different order indices) and "normal" sub-songs
-	/// or "sequences" (if the format supports them).
-	pub fn get_num_subsongs (&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_num_subsongs(self.inner)
-		}
-	}
+    /// Get the number of sub-songs.
+    ///
+    /// ### Returns
+    /// The number of sub-songs in the module.
+    ///
+    /// This includes any "hidden" songs (songs that share the same sequence,
+    /// but start at different order indices) and "normal" sub-songs
+    /// or "sequences" (if the format supports them).
+    pub fn get_num_subsongs(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_num_subsongs(self.inner) }
+    }
 
-	/// Get an instrument name.
-	///
-	/// ### Parameters
-	/// * `instrument_num` : The index of the instrument whose name should be retrieved
-	///
-	/// ### Returns
-	/// The instrument name.
-	pub fn get_instrument_name (&mut self, instrument_num: i32) -> String {
-		let opt_string = get_string!{
-			openmpt_sys::openmpt_module_get_instrument_name(self.inner, instrument_num)
-		};
-		
-		opt_string.expect("Got null pointer instead of string")
-	}
-	
-	/// Get a sample name.
-	///
-	/// ### Parameters
-	/// * `sample_num` : The index of the sample whose name should be retrieved
-	///
-	/// ### Returns
-	/// The sample name.
-	pub fn get_sample_name (&mut self, sample_num: i32) -> String {
-		let opt_string = get_string!{
-			openmpt_sys::openmpt_module_get_sample_name(self.inner, sample_num)
-		};
+    /// Get an instrument name.
+    ///
+    /// ### Parameters
+    /// * `instrument_num` : The index of the instrument whose name should be retrieved
+    ///
+    /// ### Returns
+    /// The instrument name.
+    pub fn get_instrument_name(&mut self, instrument_num: i32) -> String {
+        let opt_string = get_string! {
+            openmpt_sys::openmpt_module_get_instrument_name(self.inner, instrument_num)
+        };
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 
-	/// Get a channel name.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The index of the channel whose name should be retrieved
-	///
-	/// ### Returns
-	/// The channel name.
-	pub fn get_channel_name (&mut self, channel_num: i32) -> String {
-		let opt_string = get_string!{
-			openmpt_sys::openmpt_module_get_channel_name(self.inner, channel_num)
-		};
+    /// Get a sample name.
+    ///
+    /// ### Parameters
+    /// * `sample_num` : The index of the sample whose name should be retrieved
+    ///
+    /// ### Returns
+    /// The sample name.
+    pub fn get_sample_name(&mut self, sample_num: i32) -> String {
+        let opt_string = get_string! {
+            openmpt_sys::openmpt_module_get_sample_name(self.inner, sample_num)
+        };
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 
-	/// Get a sub-song name.
-	///
-	/// ### Parameters
-	/// * `subsong_num` : The index of the sub-song whose name should be retrieved
-	///
-	/// ### Returns
-	/// The sub-song name.
-	pub fn get_subsong_name (&mut self, subsong_num: i32) -> String {
-		let opt_string = get_string!{
-			openmpt_sys::openmpt_module_get_subsong_name(self.inner, subsong_num)
-		};
+    /// Get a channel name.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The index of the channel whose name should be retrieved
+    ///
+    /// ### Returns
+    /// The channel name.
+    pub fn get_channel_name(&mut self, channel_num: i32) -> String {
+        let opt_string = get_string! {
+            openmpt_sys::openmpt_module_get_channel_name(self.inner, channel_num)
+        };
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
+
+    /// Get a sub-song name.
+    ///
+    /// ### Parameters
+    /// * `subsong_num` : The index of the sub-song whose name should be retrieved
+    ///
+    /// ### Returns
+    /// The sub-song name.
+    pub fn get_subsong_name(&mut self, subsong_num: i32) -> String {
+        let opt_string = get_string! {
+            openmpt_sys::openmpt_module_get_subsong_name(self.inner, subsong_num)
+        };
+
+        opt_string.expect("Got null pointer instead of string")
+    }
 }
 
 impl<'m> Pattern<'m> {
-	/// Get pattern row by index.
-	///
-	/// ### Parameters
-	/// * `row_num` : The index of the row that should be retrieved.
-	///
-	/// ### Returns
-	/// A Row wrapper for the row, or None if no such row exists.
-	pub fn get_row_by_number<'p> (&'p mut self, row_num: i32) -> Option<Row<'p, 'm>> {
-		let pattern_num_rows = self.get_num_rows();
+    /// Get pattern row by index.
+    ///
+    /// ### Parameters
+    /// * `row_num` : The index of the row that should be retrieved.
+    ///
+    /// ### Returns
+    /// A Row wrapper for the row, or None if no such row exists.
+    pub fn get_row_by_number<'p>(&'p mut self, row_num: i32) -> Option<Row<'p, 'm>> {
+        let pattern_num_rows = self.get_num_rows();
 
-		assert_ne!(pattern_num_rows, 0); // Pattern does not exist
-		
-		if row_num < 0 || row_num >= pattern_num_rows {
-			None
-		} else {
-			Some(Row{ num : row_num, pattern: self })
-		}
-	}
+        assert_ne!(pattern_num_rows, 0); // Pattern does not exist
 
-	/// Get name for this pattern/order.
-	///
-	/// ### Returns
-	/// The pattern name.
-	pub fn get_name (&mut self) -> String {
-		// Order names apparently just gives you the name of the pattern
-		let opt_string = get_string!{
-			openmpt_sys::openmpt_module_get_pattern_name(self.module.inner, self.num)
-		};
+        if row_num < 0 || row_num >= pattern_num_rows {
+            None
+        } else {
+            Some(Row {
+                num: row_num,
+                pattern: self,
+            })
+        }
+    }
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+    /// Get name for this pattern/order.
+    ///
+    /// ### Returns
+    /// The pattern name.
+    pub fn get_name(&mut self) -> String {
+        // Order names apparently just gives you the name of the pattern
+        let opt_string = get_string! {
+            openmpt_sys::openmpt_module_get_pattern_name(self.module.inner, self.num)
+        };
 
-	/// Get the number of rows for this pattern.
-	///
-	/// ### Returns
-	/// The number of rows in the pattern.
-	pub fn get_num_rows(&mut self) -> i32 {
-		unsafe {
-			openmpt_sys::openmpt_module_get_pattern_num_rows(self.module.inner, self.num)
-		}
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
+
+    /// Get the number of rows for this pattern.
+    ///
+    /// ### Returns
+    /// The number of rows in the pattern.
+    pub fn get_num_rows(&mut self) -> i32 {
+        unsafe { openmpt_sys::openmpt_module_get_pattern_num_rows(self.module.inner, self.num) }
+    }
 }
 
 impl<'p, 'm> Row<'p, 'm> {
-	/// Get pattern cell by pattern channel.
-	///
-	/// ### Parameters
-	/// * `channel_num` : The index of the pattern channel at which the cell should be retrieved.
-	///
-	/// ### Returns
-	/// A Cell wrapper for the cell, or None if the channel doesn't exist.
-	pub fn get_cell_by_channel<'r> (&'r mut self, channel_num: i32) -> Option<Cell<'r, 'p, 'm>> {
-		assert!(self.num < self.pattern.get_num_rows());
-		assert!(self.num >= 0);
+    /// Get pattern cell by pattern channel.
+    ///
+    /// ### Parameters
+    /// * `channel_num` : The index of the pattern channel at which the cell should be retrieved.
+    ///
+    /// ### Returns
+    /// A Cell wrapper for the cell, or None if the channel doesn't exist.
+    pub fn get_cell_by_channel<'r>(&'r mut self, channel_num: i32) -> Option<Cell<'r, 'p, 'm>> {
+        assert!(self.num < self.pattern.get_num_rows());
+        assert!(self.num >= 0);
 
-		let num_channels = self.pattern.module.get_num_channels();
+        let num_channels = self.pattern.module.get_num_channels();
 
-		if channel_num < 0 || channel_num >= num_channels {
-			None
-		} else {
-			Some(Cell{ row: self, channel_num: channel_num })
-		}
-	}
+        if channel_num < 0 || channel_num >= num_channels {
+            None
+        } else {
+            Some(Cell {
+                row: self,
+                channel_num,
+            })
+        }
+    }
 }
 
-impl <'r, 'p, 'm> Cell<'r, 'p, 'm> {
-	/// Get all of the cell's content as a ModCommand.
-	///
-	/// ### Returns
-	/// A ModCommand containing the raw cell data as a tagged union, for easy pattern-matching.
-	pub fn get_data(&mut self) -> Result<ModCommand, String> {
-		ModCommand::new(
-			self.get_data_by_command(ModuleCommandIndex::Note),
-			self.get_data_by_command(ModuleCommandIndex::Instrument),
-			self.get_data_by_command(ModuleCommandIndex::VolumeEffect),
-			self.get_data_by_command(ModuleCommandIndex::Effect),
-			self.get_data_by_command(ModuleCommandIndex::Volume),
-			self.get_data_by_command(ModuleCommandIndex::Parameter)
-		)
-	}
+impl<'r, 'p, 'm> Cell<'r, 'p, 'm> {
+    /// Get all of the cell's content as a ModCommand.
+    ///
+    /// ### Returns
+    /// A ModCommand containing the raw cell data as a tagged union, for easy pattern-matching.
+    pub fn get_data(&mut self) -> Result<ModCommand, String> {
+        ModCommand::new(
+            self.get_data_by_command(ModuleCommandIndex::Note),
+            self.get_data_by_command(ModuleCommandIndex::Instrument),
+            self.get_data_by_command(ModuleCommandIndex::VolumeEffect),
+            self.get_data_by_command(ModuleCommandIndex::Effect),
+            self.get_data_by_command(ModuleCommandIndex::Volume),
+            self.get_data_by_command(ModuleCommandIndex::Parameter),
+        )
+    }
 
-	/// Get raw cell content.
-	///
-	/// ### Parameters
-	/// * `command` : The cell index at which the data should be retrieved, from `ModuleCommandIndex`.
-	///
-	/// ### Returns
-	/// The internal, raw cell data at the given command index.
-	pub fn get_data_by_command(&mut self, command : ModuleCommandIndex) -> u8 {
-		unsafe{
-			openmpt_sys::openmpt_module_get_pattern_row_channel_command(
-				self.row.pattern.module.inner,
-				self.row.pattern.num,
-				self.row.num,
-				self.channel_num,
-				command.value()
-			)
-		}
-	}
+    /// Get raw cell content.
+    ///
+    /// ### Parameters
+    /// * `command` : The cell index at which the data should be retrieved, from `ModuleCommandIndex`.
+    ///
+    /// ### Returns
+    /// The internal, raw cell data at the given command index.
+    pub fn get_data_by_command(&mut self, command: ModuleCommandIndex) -> u8 {
+        unsafe {
+            openmpt_sys::openmpt_module_get_pattern_row_channel_command(
+                self.row.pattern.module.inner,
+                self.row.pattern.num,
+                self.row.num,
+                self.channel_num,
+                command.value(),
+            )
+        }
+    }
 
-	/// Get formatted (human-readable) cell content.
-	///
-	/// ### Parameters
-	/// * `width` : The maximum number of characters the string should contain. 0 means no limit.
-	/// * `pad` : 	If true, the string will be resized to the exact length provided in the width parameter.
-	///
-	/// ### Returns
-	/// The formatted pattern data for that cell.
-	pub fn get_formatted(&mut self, width: usize, pad: bool) -> String {
-		let opt_string = get_string!({
-			openmpt_sys::openmpt_module_format_pattern_row_channel(
-				self.row.pattern.module.inner,
-				self.row.pattern.num,
-				self.row.num,
-				self.channel_num,
-				width,
-				pad as c_int
-			)
-		});
+    /// Get formatted (human-readable) cell content.
+    ///
+    /// ### Parameters
+    /// * `width` : The maximum number of characters the string should contain. 0 means no limit.
+    /// * `pad` : 	If true, the string will be resized to the exact length provided in the width parameter.
+    ///
+    /// ### Returns
+    /// The formatted pattern data for that cell.
+    pub fn get_formatted(&mut self, width: usize, pad: bool) -> String {
+        let opt_string = get_string!({
+            openmpt_sys::openmpt_module_format_pattern_row_channel(
+                self.row.pattern.module.inner,
+                self.row.pattern.num,
+                self.row.num,
+                self.channel_num,
+                width,
+                pad as c_int,
+            )
+        });
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 
-	/// Get formatted (human-readable) cell content.
-	///
-	/// ### Parameters
-	/// * `command` : The cell index at which the data should be retrieved, from `ModuleCommandIndex`.
-	///
-	/// ### Returns
-	/// The formatted pattern data for that cell, at the given command index.
-	pub fn get_formatted_by_command(&mut self, command: ModuleCommandIndex) -> String {
-		let opt_string = get_string!({
-			openmpt_sys::openmpt_module_format_pattern_row_channel_command(
-				self.row.pattern.module.inner,
-				self.row.pattern.num,
-				self.row.num,
-				self.channel_num,
-				command.value()
-			)
-		});
+    /// Get formatted (human-readable) cell content.
+    ///
+    /// ### Parameters
+    /// * `command` : The cell index at which the data should be retrieved, from `ModuleCommandIndex`.
+    ///
+    /// ### Returns
+    /// The formatted pattern data for that cell, at the given command index.
+    pub fn get_formatted_by_command(&mut self, command: ModuleCommandIndex) -> String {
+        let opt_string = get_string!({
+            openmpt_sys::openmpt_module_format_pattern_row_channel_command(
+                self.row.pattern.module.inner,
+                self.row.pattern.num,
+                self.row.num,
+                self.channel_num,
+                command.value(),
+            )
+        });
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 
-	/// Get highlighting information for formatted cell content.
-	///
-	/// ### Parameters
-	/// * `width` : The maximum number of characters the string should contain. 0 means no limit.
-	/// * `pad` : 	If true, the string will be resized to the exact length provided in the width parameter.
-	///
-	/// ### Returns
-	/// The highlighting string for the formatted pattern data as retrieved by `get_formatted` for that cell.
-	pub fn get_highlight(&mut self, width: usize, pad: bool) -> String {
-		let opt_string = get_string!({
-			openmpt_sys::openmpt_module_highlight_pattern_row_channel(
-				self.row.pattern.module.inner,
-				self.row.pattern.num,
-				self.row.num,
-				self.channel_num,
-				width,
-				pad as c_int
-			)
-		});
+    /// Get highlighting information for formatted cell content.
+    ///
+    /// ### Parameters
+    /// * `width` : The maximum number of characters the string should contain. 0 means no limit.
+    /// * `pad` : 	If true, the string will be resized to the exact length provided in the width parameter.
+    ///
+    /// ### Returns
+    /// The highlighting string for the formatted pattern data as retrieved by `get_formatted` for that cell.
+    pub fn get_highlight(&mut self, width: usize, pad: bool) -> String {
+        let opt_string = get_string!({
+            openmpt_sys::openmpt_module_highlight_pattern_row_channel(
+                self.row.pattern.module.inner,
+                self.row.pattern.num,
+                self.row.num,
+                self.channel_num,
+                width,
+                pad as c_int,
+            )
+        });
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 
-	/// Get highlighting information for formatted pattern content.
-	///
-	/// ### Parameters
-	/// * `command` : The cell index at which the data should be retrieved, from `ModuleCommandIndex`.
-	///
-	/// ### Returns
-	/// The highlighting string for the formatted pattern data as retrieved by `get_formatted` for that cell, at the given command index.
-	pub fn get_highlight_by_command(&mut self, command: ModuleCommandIndex) -> String {
-		let opt_string = get_string!({
-			openmpt_sys::openmpt_module_highlight_pattern_row_channel_command(
-				self.row.pattern.module.inner,
-				self.row.pattern.num,
-				self.row.num,
-				self.channel_num,
-				command.value()
-			)
-		});
+    /// Get highlighting information for formatted pattern content.
+    ///
+    /// ### Parameters
+    /// * `command` : The cell index at which the data should be retrieved, from `ModuleCommandIndex`.
+    ///
+    /// ### Returns
+    /// The highlighting string for the formatted pattern data as retrieved by `get_formatted` for that cell, at the given command index.
+    pub fn get_highlight_by_command(&mut self, command: ModuleCommandIndex) -> String {
+        let opt_string = get_string!({
+            openmpt_sys::openmpt_module_highlight_pattern_row_channel_command(
+                self.row.pattern.module.inner,
+                self.row.pattern.num,
+                self.row.num,
+                self.channel_num,
+                command.value(),
+            )
+        });
 
-		opt_string.expect("Got null pointer instead of string")
-	}
+        opt_string.expect("Got null pointer instead of string")
+    }
 }
 
 /// Parameter index to use with `get_data_by_command`,
 /// `get_formatted_by_command` and `get_highlight_by_command`.
 pub enum ModuleCommandIndex {
-	Note,
-	Instrument,
-	VolumeEffect,
-	Effect,
-	Volume,
-	Parameter,
+    Note,
+    Instrument,
+    VolumeEffect,
+    Effect,
+    Volume,
+    Parameter,
 }
 
 impl ModuleCommandIndex {
-	fn value(&self) -> c_int {
-		match *self {
-			ModuleCommandIndex::Note => 0,
-			ModuleCommandIndex::Instrument => 1,
-			ModuleCommandIndex::VolumeEffect => 2,
-			ModuleCommandIndex::Effect => 3,
-			ModuleCommandIndex::Volume => 4,
-			ModuleCommandIndex::Parameter => 5,
-		}
-	}
+    fn value(&self) -> c_int {
+        match *self {
+            ModuleCommandIndex::Note => 0,
+            ModuleCommandIndex::Instrument => 1,
+            ModuleCommandIndex::VolumeEffect => 2,
+            ModuleCommandIndex::Effect => 3,
+            ModuleCommandIndex::Volume => 4,
+            ModuleCommandIndex::Parameter => 5,
+        }
+    }
 }
-
 
 #[cfg(test)]
 mod tests {
-	use super::super::test_helper;
+    use super::super::test_helper;
 
-	#[test]
-	fn empty_module_list_names() {
-		// None of these should panic from a null return value
-		let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
+    #[test]
+    fn empty_module_list_names() {
+        // None of these should panic from a null return value
+        let mut module = test_helper::load_file_as_module("empty_module.xm").unwrap();
 
-		if module.get_num_orders() > 0 {
-			let mut pattern = module.get_pattern_by_order(0).unwrap();
-			println!("Name of Pattern #0 : {:?}", pattern.get_name());
-		}
+        if module.get_num_orders() > 0 {
+            let mut pattern = module.get_pattern_by_order(0).unwrap();
+            println!("Name of Pattern #0 : {:?}", pattern.get_name());
+        }
 
-		if module.get_num_channels() > 0 {
-			println!("Name of Channel #0 : {:?}", module.get_channel_name(0));
-		}
+        if module.get_num_channels() > 0 {
+            println!("Name of Channel #0 : {:?}", module.get_channel_name(0));
+        }
 
-		if module.get_num_instruments() > 0 {
-			println!("Name of Instrument #0 : {:?}", module.get_instrument_name(0));
-		}
+        if module.get_num_instruments() > 0 {
+            println!(
+                "Name of Instrument #0 : {:?}",
+                module.get_instrument_name(0)
+            );
+        }
 
-		if module.get_num_samples() > 0 {
-			println!("Name of Sample #0 : {:?}", module.get_sample_name(0));
-		}
+        if module.get_num_samples() > 0 {
+            println!("Name of Sample #0 : {:?}", module.get_sample_name(0));
+        }
 
-		if module.get_num_subsongs() > 0 {
-			println!("Name of Subsong #0 : {:?}", module.get_subsong_name(0));
-		}
-	}
+        if module.get_num_subsongs() > 0 {
+            println!("Name of Subsong #0 : {:?}", module.get_subsong_name(0));
+        }
+    }
 
-	#[test]
-	fn unatco_iterative_reading() {
-		iterative_reading("UNATCO.it");
-	}
+    #[test]
+    fn unatco_iterative_reading() {
+        iterative_reading("UNATCO.it");
+    }
 
-	fn iterative_reading(file_name : &str) {
-		let mut module = test_helper::load_file_as_module(file_name).unwrap();
-		let num_orders = module.get_num_orders();
-		let num_channels = module.get_num_channels();
+    fn iterative_reading(file_name: &str) {
+        let mut module = test_helper::load_file_as_module(file_name).unwrap();
+        let num_orders = module.get_num_orders();
+        let num_channels = module.get_num_channels();
 
-		for order_num in 0..num_orders {
-			let mut pattern = module.get_pattern_by_order(order_num).unwrap();
-			let num_rows = pattern.get_num_rows();
+        for order_num in 0..num_orders {
+            let mut pattern = module.get_pattern_by_order(order_num).unwrap();
+            let num_rows = pattern.get_num_rows();
 
-			println!("Checking pattern #{} ({} rows, {} channels)", order_num, num_rows, num_channels);
+            println!(
+                "Checking pattern #{} ({} rows, {} channels)",
+                order_num, num_rows, num_channels
+            );
 
-			for row_num in 0..num_rows {
-				let mut row = pattern.get_row_by_number(row_num).unwrap();
-				let mut row_string = String::new();
+            for row_num in 0..num_rows {
+                let mut row = pattern.get_row_by_number(row_num).unwrap();
+                let mut row_string = String::new();
 
-				for channel_num in 0..num_channels {
-					let mut cell = row.get_cell_by_channel(channel_num).unwrap();
-					assert!(cell.get_data().is_ok());
+                for channel_num in 0..num_channels {
+                    let mut cell = row.get_cell_by_channel(channel_num).unwrap();
+                    assert!(cell.get_data().is_ok());
 
-					if channel_num != 0 { row_string.push_str("|"); }
-					row_string.push_str(cell.get_formatted(0, false).as_str());
-				}
-				//println!("{}", row_string);
-			}
-		}
-	}
+                    if channel_num != 0 {
+                        row_string.push_str("|");
+                    }
+                    row_string.push_str(cell.get_formatted(0, false).as_str());
+                }
+                //println!("{}", row_string);
+            }
+        }
+    }
 }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -33,6 +33,9 @@ pub struct Module {
 	inner : *mut openmpt_sys::openmpt_module,
 }
 
+// According to the libopenmpt docs: "Consecutive accesses can happen from different threads."
+unsafe impl Send for Module {}
+
 impl Drop for Module {
 	fn drop(&mut self) {
 		unsafe {


### PR DESCRIPTION
This PR unsafely implements `send` for `openmpt::module::Module`. This is safe because the openmpt documentation states:

> - You must ensure to only ever access a particular libopenmpt object from a
>   single thread at a time.
> - **Consecutive accesses can happen from different threads.**
> - Different objects can be accessed concurrently from different threads.

So objects created by libopenmpt are `Send`, but not `Sync`.

I also fixed a few of the clippy warnings by E.G. replacing the deprecated `x...y` inclusive range operator with the newer `x..=y`.

I noticed that this repository hasn't been touched in quite a while, so I thaught I'd let you know I'd be happy to take over this project if you've lost interest / don't have the time any more. There are quite a few things I'd love to do to improve the API (better error handling, less copying when dealing with strings allocated on the libopenmpt side, etc). If you'd like to keep it though, no worries at all, just thaught I'd offer.